### PR TITLE
✨ Ability to disable preview of assets using flag (showPreview)

### DIFF
--- a/example/lib/pages/custom_picker_page.dart
+++ b/example/lib/pages/custom_picker_page.dart
@@ -935,66 +935,63 @@ class FileAssetPickerBuilder
           index = selectedAssets.indexWhere((File f) => f.path == asset.path);
         }
         final double indicatorSize = Screens.width / gridCount / 3;
-        final GestureDetector selectorWidget = GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () {
-            if (isSelected) {
-              provider.unSelectAsset(asset);
-            } else {
-              if (isSingleAssetMode) {
-                provider.selectedAssets.clear();
+        return Positioned(
+          top: 0.0,
+          right: 0.0,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              if (isSelected) {
+                provider.unSelectAsset(asset);
+              } else {
+                if (isSingleAssetMode) {
+                  provider.selectedAssets.clear();
+                }
+                provider.selectAsset(asset);
               }
-              provider.selectAsset(asset);
-              if (isSingleAssetMode && specialPickerType == SpecialPickerType.noPreview) {
-                Navigator.of(context).pop(provider.selectedAssets);
-              }
-            }
-          },
-          child: Container(
-            margin: EdgeInsets.all(
-              Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
-            ),
-            width: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
-            height: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
-            alignment: AlignmentDirectional.topEnd,
-            child: AnimatedContainer(
-              duration: switchingPathDuration,
-              width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-              height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-              decoration: BoxDecoration(
-                border: !isSelected
-                    ? Border.all(color: Colors.white, width: 2.0)
-                    : null,
-                color: isSelected ? themeColor : null,
-                shape: BoxShape.circle,
+            },
+            child: Container(
+              margin: EdgeInsets.all(
+                Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
               ),
-              child: AnimatedSwitcher(
+              width: indicatorSize,
+              height: indicatorSize,
+              alignment: AlignmentDirectional.topEnd,
+              child: AnimatedContainer(
                 duration: switchingPathDuration,
-                reverseDuration: switchingPathDuration,
-                child: isSelected
-                    ? isSingleAssetMode
-                        ? const Icon(Icons.check, size: 18.0)
-                        : Text(
-                            '${index + 1}',
-                            style: TextStyle(
-                              color: isSelected
-                                  ? theme.textTheme.bodyText1?.color
-                                  : null,
-                              fontSize: isAppleOS ? 16.0 : 14.0,
-                              fontWeight: isAppleOS
-                                  ? FontWeight.w600
-                                  : FontWeight.bold,
-                            ),
-                          )
-                    : const SizedBox.shrink(),
+                width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+                height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+                decoration: BoxDecoration(
+                  border: !isSelected
+                      ? Border.all(color: Colors.white, width: 2.0)
+                      : null,
+                  color: isSelected ? themeColor : null,
+                  shape: BoxShape.circle,
+                ),
+                child: AnimatedSwitcher(
+                  duration: switchingPathDuration,
+                  reverseDuration: switchingPathDuration,
+                  child: isSelected
+                      ? isSingleAssetMode
+                          ? const Icon(Icons.check, size: 18.0)
+                          : Text(
+                              '${index + 1}',
+                              style: TextStyle(
+                                color: isSelected
+                                    ? theme.textTheme.bodyText1?.color
+                                    : null,
+                                fontSize: isAppleOS ? 16.0 : 14.0,
+                                fontWeight: isAppleOS
+                                    ? FontWeight.w600
+                                    : FontWeight.bold,
+                              ),
+                            )
+                      : const SizedBox.shrink(),
+                ),
               ),
             ),
           ),
         );
-        if (specialPickerType != SpecialPickerType.noPreview) {
-          return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
-        }
-        return selectorWidget;
       },
     );
   }

--- a/example/lib/pages/custom_picker_page.dart
+++ b/example/lib/pages/custom_picker_page.dart
@@ -945,7 +945,7 @@ class FileAssetPickerBuilder
                 provider.selectedAssets.clear();
               }
               provider.selectAsset(asset);
-              if (isSingleAssetMode && specialPickerType == SpecialPickerType.disablePreview) {
+              if (isSingleAssetMode && specialPickerType == SpecialPickerType.noPreview) {
                 Navigator.of(context).pop(provider.selectedAssets);
               }
             }
@@ -954,8 +954,8 @@ class FileAssetPickerBuilder
             margin: EdgeInsets.all(
               Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
             ),
-            width: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
-            height: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
+            width: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
+            height: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
             alignment: AlignmentDirectional.topEnd,
             child: AnimatedContainer(
               duration: switchingPathDuration,
@@ -991,8 +991,9 @@ class FileAssetPickerBuilder
             ),
           ),
         );
-        if (specialPickerType != SpecialPickerType.disablePreview) {
+        if (specialPickerType != SpecialPickerType.noPreview) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
+        }
         return selectorWidget;
       },
     );

--- a/example/lib/pages/custom_picker_page.dart
+++ b/example/lib/pages/custom_picker_page.dart
@@ -993,9 +993,7 @@ class FileAssetPickerBuilder
         );
         if (specialPickerType != SpecialPickerType.disablePreview) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
-        } else {
-          return selectorWidget;
-        }
+        return selectorWidget;
       },
     );
   }

--- a/example/lib/pages/custom_picker_page.dart
+++ b/example/lib/pages/custom_picker_page.dart
@@ -935,63 +935,67 @@ class FileAssetPickerBuilder
           index = selectedAssets.indexWhere((File f) => f.path == asset.path);
         }
         final double indicatorSize = Screens.width / gridCount / 3;
-        return Positioned(
-          top: 0.0,
-          right: 0.0,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () {
-              if (isSelected) {
-                provider.unSelectAsset(asset);
-              } else {
-                if (isSingleAssetMode) {
-                  provider.selectedAssets.clear();
-                }
-                provider.selectAsset(asset);
+        final GestureDetector selectorWidget = GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            if (isSelected) {
+              provider.unSelectAsset(asset);
+            } else {
+              if (isSingleAssetMode) {
+                provider.selectedAssets.clear();
               }
-            },
-            child: Container(
-              margin: EdgeInsets.all(
-                Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
+              provider.selectAsset(asset);
+              if (isSingleAssetMode && !showPreview) {
+                Navigator.of(context).pop(provider.selectedAssets);
+              }
+            }
+          },
+          child: Container(
+            margin: EdgeInsets.all(
+              Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
+            ),
+            width: showPreview ? indicatorSize : null,
+            height: showPreview ? indicatorSize : null,
+            alignment: AlignmentDirectional.topEnd,
+            child: AnimatedContainer(
+              duration: switchingPathDuration,
+              width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+              height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+              decoration: BoxDecoration(
+                border: !isSelected
+                    ? Border.all(color: Colors.white, width: 2.0)
+                    : null,
+                color: isSelected ? themeColor : null,
+                shape: BoxShape.circle,
               ),
-              width: indicatorSize,
-              height: indicatorSize,
-              alignment: AlignmentDirectional.topEnd,
-              child: AnimatedContainer(
+              child: AnimatedSwitcher(
                 duration: switchingPathDuration,
-                width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-                height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-                decoration: BoxDecoration(
-                  border: !isSelected
-                      ? Border.all(color: Colors.white, width: 2.0)
-                      : null,
-                  color: isSelected ? themeColor : null,
-                  shape: BoxShape.circle,
-                ),
-                child: AnimatedSwitcher(
-                  duration: switchingPathDuration,
-                  reverseDuration: switchingPathDuration,
-                  child: isSelected
-                      ? isSingleAssetMode
-                          ? const Icon(Icons.check, size: 18.0)
-                          : Text(
-                              '${index + 1}',
-                              style: TextStyle(
-                                color: isSelected
-                                    ? theme.textTheme.bodyText1?.color
-                                    : null,
-                                fontSize: isAppleOS ? 16.0 : 14.0,
-                                fontWeight: isAppleOS
-                                    ? FontWeight.w600
-                                    : FontWeight.bold,
-                              ),
-                            )
-                      : const SizedBox.shrink(),
-                ),
+                reverseDuration: switchingPathDuration,
+                child: isSelected
+                    ? isSingleAssetMode
+                        ? const Icon(Icons.check, size: 18.0)
+                        : Text(
+                            '${index + 1}',
+                            style: TextStyle(
+                              color: isSelected
+                                  ? theme.textTheme.bodyText1?.color
+                                  : null,
+                              fontSize: isAppleOS ? 16.0 : 14.0,
+                              fontWeight: isAppleOS
+                                  ? FontWeight.w600
+                                  : FontWeight.bold,
+                            ),
+                          )
+                    : const SizedBox.shrink(),
               ),
             ),
           ),
         );
+        if (showPreview) {
+          return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
+        } else {
+          return selectorWidget;
+        }
       },
     );
   }

--- a/example/lib/pages/custom_picker_page.dart
+++ b/example/lib/pages/custom_picker_page.dart
@@ -945,7 +945,7 @@ class FileAssetPickerBuilder
                 provider.selectedAssets.clear();
               }
               provider.selectAsset(asset);
-              if (isSingleAssetMode && !showPreview) {
+              if (isSingleAssetMode && specialPickerType == SpecialPickerType.disablePreview) {
                 Navigator.of(context).pop(provider.selectedAssets);
               }
             }
@@ -954,8 +954,8 @@ class FileAssetPickerBuilder
             margin: EdgeInsets.all(
               Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
             ),
-            width: showPreview ? indicatorSize : null,
-            height: showPreview ? indicatorSize : null,
+            width: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
+            height: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
             alignment: AlignmentDirectional.topEnd,
             child: AnimatedContainer(
               duration: switchingPathDuration,
@@ -991,7 +991,7 @@ class FileAssetPickerBuilder
             ),
           ),
         );
-        if (showPreview) {
+        if (specialPickerType != SpecialPickerType.disablePreview) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
         } else {
           return selectorWidget;

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -17,7 +17,6 @@ class MultiAssetsPage extends StatefulWidget {
 
 class _MultiAssetsPageState extends State<MultiAssetsPage> {
   final int maxAssetsCount = 9;
-  final SpecialPickerType? specialPickerType = null;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -41,7 +40,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -58,7 +56,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -75,7 +72,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -112,7 +108,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                   ),
                 );
               },
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -129,7 +124,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -149,7 +143,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -175,7 +168,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                     ),
                   ),
                 ),
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -196,7 +188,23 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               specialItemBuilder: (BuildContext context) {
                 return const Center(child: Text('Custom Widget'));
               },
-              specialPickerType: specialPickerType,
+            );
+          },
+        ),
+        PickMethodModel(
+          icon: '🚀',
+          name: 'No preview',
+          description: 'Pick assets like the WhatsApp/MegaTok pattern.',
+          method: (
+            BuildContext context,
+            List<AssetEntity> assets,
+          ) async {
+            return await AssetPicker.pickAssets(
+              context,
+              maxAssets: maxAssetsCount,
+              selectedAssets: assets,
+              requestType: RequestType.common,
+              specialPickerType: SpecialPickerType.noPreview,
             );
           },
         ),
@@ -215,7 +223,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               selectedAssets: assets,
               requestType: RequestType.image,
               previewThumbSize: const <int>[300, 300],
-              specialPickerType: specialPickerType,
             );
           },
         ),

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -17,6 +17,7 @@ class MultiAssetsPage extends StatefulWidget {
 
 class _MultiAssetsPageState extends State<MultiAssetsPage> {
   final int maxAssetsCount = 9;
+  final bool showPreview = true;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -40,6 +41,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
+              showPreview: showPreview,
             );
           },
         ),
@@ -56,6 +58,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
+              showPreview: showPreview,
             );
           },
         ),
@@ -72,6 +75,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
+              showPreview: showPreview,
             );
           },
         ),
@@ -108,6 +112,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                   ),
                 );
               },
+              showPreview: showPreview,
             );
           },
         ),
@@ -124,6 +129,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
+              showPreview: showPreview,
             );
           },
         ),
@@ -143,6 +149,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
+              showPreview: showPreview,
             );
           },
         ),
@@ -168,6 +175,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                     ),
                   ),
                 ),
+              showPreview: showPreview,
             );
           },
         ),
@@ -188,6 +196,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               specialItemBuilder: (BuildContext context) {
                 return const Center(child: Text('Custom Widget'));
               },
+              showPreview: showPreview,
             );
           },
         ),
@@ -206,6 +215,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               selectedAssets: assets,
               requestType: RequestType.image,
               previewThumbSize: const <int>[300, 300],
+              showPreview: showPreview,
             );
           },
         ),

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -17,7 +17,7 @@ class MultiAssetsPage extends StatefulWidget {
 
 class _MultiAssetsPageState extends State<MultiAssetsPage> {
   final int maxAssetsCount = 9;
-  final bool showPreview = true;
+  final SpecialPickerType? specialPickerType = null;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -41,7 +41,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -58,7 +58,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -75,7 +75,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -112,7 +112,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                   ),
                 );
               },
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -129,7 +129,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -149,7 +149,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -175,7 +175,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
                     ),
                   ),
                 ),
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -196,7 +196,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               specialItemBuilder: (BuildContext context) {
                 return const Center(child: Text('Custom Widget'));
               },
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -215,7 +215,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage> {
               selectedAssets: assets,
               requestType: RequestType.image,
               previewThumbSize: const <int>[300, 300],
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -194,6 +194,23 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
             );
           },
         ),
+        PickMethodModel(
+          icon: '🚀',
+          name: 'No preview',
+          description: 'Pick assets like the WhatsApp/MegaTok pattern.',
+          method: (
+            BuildContext context,
+            List<AssetEntity> assets,
+          ) async {
+            return await AssetPicker.pickAssets(
+              context,
+              maxAssets: maxAssetsCount,
+              selectedAssets: assets,
+              requestType: RequestType.common,
+              specialPickerType: SpecialPickerType.noPreview,
+            );
+          },
+        ),
       ];
 
   Future<void> selectAssets(PickMethodModel model) async {

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -17,7 +17,6 @@ class SingleAssetPage extends StatefulWidget {
 
 class _SingleAssetPageState extends State<SingleAssetPage> {
   final int maxAssetsCount = 1;
-  final SpecialPickerType?  specialPickerType = null;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -41,7 +40,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -58,7 +56,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -75,7 +72,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -111,7 +107,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                   ),
                 );
               },
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -128,7 +123,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -148,7 +142,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.all,
-              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -174,7 +167,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                     ),
                   ),
                 ),
-              specialPickerType: specialPickerType,
             );
           },
         ),

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -17,6 +17,7 @@ class SingleAssetPage extends StatefulWidget {
 
 class _SingleAssetPageState extends State<SingleAssetPage> {
   final int maxAssetsCount = 1;
+  final bool showPreview = true;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -40,6 +41,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
+              showPreview: showPreview,
             );
           },
         ),
@@ -56,6 +58,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
+              showPreview: showPreview,
             );
           },
         ),
@@ -72,6 +75,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
+              showPreview: showPreview,
             );
           },
         ),
@@ -107,6 +111,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                   ),
                 );
               },
+              showPreview: showPreview,
             );
           },
         ),
@@ -123,6 +128,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
+              showPreview: showPreview,
             );
           },
         ),
@@ -142,6 +148,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.all,
+              showPreview: showPreview,
             );
           },
         ),
@@ -167,6 +174,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                     ),
                   ),
                 ),
+              showPreview: showPreview,
             );
           },
         ),
@@ -183,6 +191,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               specialPickerType: SpecialPickerType.wechatMoment,
+              showPreview: showPreview,
             );
           },
         ),

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -17,7 +17,7 @@ class SingleAssetPage extends StatefulWidget {
 
 class _SingleAssetPageState extends State<SingleAssetPage> {
   final int maxAssetsCount = 1;
-  final bool showPreview = true;
+  final SpecialPickerType?  specialPickerType = null;
 
   List<AssetEntity> assets = <AssetEntity>[];
 
@@ -41,7 +41,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.image,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -58,7 +58,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.video,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -75,7 +75,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.audio,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -111,7 +111,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                   ),
                 );
               },
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -128,7 +128,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.common,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -148,7 +148,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               requestType: RequestType.all,
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -174,7 +174,7 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
                     ),
                   ),
                 ),
-              showPreview: showPreview,
+              specialPickerType: specialPickerType,
             );
           },
         ),
@@ -191,7 +191,6 @@ class _SingleAssetPageState extends State<SingleAssetPage> {
               maxAssets: maxAssetsCount,
               selectedAssets: assets,
               specialPickerType: SpecialPickerType.wechatMoment,
-              showPreview: showPreview,
             );
           },
         ),

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -25,7 +25,7 @@ enum SpecialPickerType {
   /// 用户在点击网格的 item 时无法进入预览。
   /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
   /// 而在单选模式下将直接返回点击的资源。
-  noPreview
+  noPreview,
 }
 
 /// Provide an item slot for custom widget insertion.

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -7,13 +7,24 @@
 /// un-common pick pattern.
 /// 提供一些特殊的选择器类型以整合非常规的选择行为。
 enum SpecialPickerType { 
-  /// WeChat Moments mode
+  /// WeChat Moments mode.
   /// 微信朋友圈模式
-  wechatMoment, 
-
-  /// Disable preview of assets
+  ///
+  /// The user can only select *one video* or *multiple images* at the same time,
+  /// and those two asset types cannot be selected at the same time.
+  /// 用户只可以选择 **一个视频** 或 **多个图片**，并且两种类型互斥。
+  wechatMoment,
+  /// Disable preview of assets.
   /// 禁用资产预览
-  disablePreview 
+  ///
+  /// There is no preview mode when clicking grid items.
+  /// In multiple select mode, any click (either on the select indicator or on
+  /// the asset itself) will select the asset.
+  /// In single select mode, any click directly selects the asset and returns.
+  /// 用户在点击网格的 item 时无法进入预览。
+  /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
+  /// 而在单选模式下将直接返回点击的资源。
+  noPreview
 }
 
 /// Provide an item slot for custom widget insertion.

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -14,6 +14,7 @@ enum SpecialPickerType {
   /// and those two asset types cannot be selected at the same time.
   /// 用户只可以选择 **一个视频** 或 **多个图片**，并且两种类型互斥。
   wechatMoment,
+
   /// Disable preview of assets.
   /// 禁用资产预览
   ///

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -16,7 +16,7 @@ enum SpecialPickerType {
   wechatMoment,
 
   /// Disable preview of assets.
-  /// 禁用资产预览
+  /// 禁用资源预览
   ///
   /// There is no preview mode when clicking grid items.
   /// In multiple select mode, any click (either on the select indicator or on

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -6,7 +6,15 @@
 /// Provide some special picker types to integrate
 /// un-common pick pattern.
 /// 提供一些特殊的选择器类型以整合非常规的选择行为。
-enum SpecialPickerType { wechatMoment }
+enum SpecialPickerType { 
+  /// WeChat Moments mode
+  /// 微信朋友圈模式
+  wechatMoment, 
+
+  /// Disable preview of assets
+  /// 禁用资产预览
+  disablePreview 
+}
 
 /// Provide an item slot for custom widget insertion.
 /// 提供一个自定义位置供特殊item放入资源列表中。

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -463,7 +463,7 @@ class DefaultAssetPickerBuilderDelegate
   ///
   /// 这里包含一些特殊选择类型：
   /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。当用户选择了视频，将不能选择图片。
-  /// * [SpecialPickerType.noPreview] 禁用资产预览； 单击资产将其选中。
+  /// * [SpecialPickerType.noPreview] 禁用资源预览。多选时单击资产将直接选中，单选时选中并返回。
   final SpecialPickerType? specialPickerType;
 
   /// [Duration] when triggering path switching.

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -35,7 +35,6 @@ abstract class AssetPickerBuilderDelegate<A, P> {
     this.specialItemBuilder,
     this.loadingIndicatorBuilder,
     this.allowSpecialItemWhenEmpty = false,
-    this.specialPickerType,
   })  : assert(
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
@@ -82,20 +81,6 @@ abstract class AssetPickerBuilderDelegate<A, P> {
   /// Whether the special item will display or not when assets is empty.
   /// 当没有资源时是否显示自定义item
   final bool allowSpecialItemWhenEmpty;
-
-  /// The current special picker type for the picker.
-  /// 当前特殊选择类型
-  ///
-  /// There're several types which are special:
-  /// * [SpecialPickerType.wechatMoment] When user selected video, no more images
-  /// can be selected.
-  /// * [SpecialPickerType.noPreview] Disable preview of asset; Clicking on an
-  /// asset selects it.
-  ///
-  /// 这里包含一些特殊选择类型：
-  /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。当用户选择了视频，将不能选择图片。
-  /// * [SpecialPickerType.noPreview] 禁用资产预览； 单击资产将其选中。
-  final SpecialPickerType? specialPickerType;
 
   /// The [ScrollController] for the preview grid.
   final ScrollController gridScrollController = ScrollController();
@@ -343,7 +328,7 @@ abstract class AssetPickerBuilderDelegate<A, P> {
       child: Row(children: <Widget>[
         if (!isSingleAssetMode || !isAppleOS) previewButton(context),
         if (isAppleOS) const Spacer(),
-        if (isAppleOS && ((specialPickerType != SpecialPickerType.noPreview) || !isSingleAssetMode)) confirmButton(context),
+        if (isAppleOS) confirmButton(context),
       ]),
     );
     if (isAppleOS) {
@@ -437,7 +422,7 @@ class DefaultAssetPickerBuilderDelegate
     IndicatorBuilder? loadingIndicatorBuilder,
     bool allowSpecialItemWhenEmpty = false,
     this.previewThumbSize,
-    SpecialPickerType? specialPickerType,
+    this.specialPickerType,
   })  : assert(
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
@@ -452,7 +437,6 @@ class DefaultAssetPickerBuilderDelegate
           specialItemBuilder: specialItemBuilder,
           loadingIndicatorBuilder: loadingIndicatorBuilder,
           allowSpecialItemWhenEmpty: allowSpecialItemWhenEmpty,
-          specialPickerType: specialPickerType,
         );
 
   /// Preview thumbnail size in the viewer.
@@ -467,6 +451,20 @@ class DefaultAssetPickerBuilderDelegate
   /// Default is `null`, which will request the origin data.
   /// 默认为空，即读取原图。
   final List<int>? previewThumbSize;
+
+  /// The current special picker type for the picker.
+  /// 当前特殊选择类型
+  ///
+  /// There're several types which are special:
+  /// * [SpecialPickerType.wechatMoment] When user selected video, no more images
+  /// can be selected.
+  /// * [SpecialPickerType.noPreview] Disable preview of asset; Clicking on an
+  /// asset selects it.
+  ///
+  /// 这里包含一些特殊选择类型：
+  /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。当用户选择了视频，将不能选择图片。
+  /// * [SpecialPickerType.noPreview] 禁用资产预览； 单击资产将其选中。
+  final SpecialPickerType? specialPickerType;
 
   /// [Duration] when triggering path switching.
   /// 切换路径时的动画时长

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -455,7 +455,7 @@ class DefaultAssetPickerBuilderDelegate
   /// The current special picker type for the picker.
   /// 当前特殊选择类型
   ///
-  /// There're several types which are special:
+  /// Several types which are special:
   /// * [SpecialPickerType.wechatMoment] When user selected video, no more images
   /// can be selected.
   /// * [SpecialPickerType.noPreview] Disable preview of asset; Clicking on an
@@ -474,8 +474,8 @@ class DefaultAssetPickerBuilderDelegate
   /// 切换路径时的动画曲线
   Curve get switchingPathCurve => Curves.easeInOut;
 
-  /// [bool] Does picker type enable preview.
-  /// 选择器类型是否启用预览
+  /// [bool] Whether the preview of assets is enabled.
+  /// 资源的预览是否启用
   bool get isPreviewEnabled => specialPickerType != SpecialPickerType.noPreview;
 
   @override
@@ -498,7 +498,8 @@ class DefaultAssetPickerBuilderDelegate
                         child: Column(
                           children: <Widget>[
                             Expanded(child: assetsGridBuilder(context)),
-                            if (!isSingleAssetMode && isPreviewEnabled) bottomActionBar(context),
+                            if (!isSingleAssetMode && isPreviewEnabled)
+                              bottomActionBar(context),
                           ],
                         ),
                       ),
@@ -520,7 +521,9 @@ class DefaultAssetPickerBuilderDelegate
       centerTitle: isAppleOS,
       title: pathEntitySelector(context),
       leading: backButton(context),
-      actions: !isAppleOS && (isPreviewEnabled || !isSingleAssetMode) ? <Widget>[confirmButton(context)] : null,
+      actions: !isAppleOS && (isPreviewEnabled || !isSingleAssetMode)
+          ? <Widget>[confirmButton(context)]
+          : null,
       actionsPadding: const EdgeInsets.only(right: 14.0),
       blurRadius: isAppleOS ? appleOSBlurRadius : 0.0,
     );
@@ -544,7 +547,8 @@ class DefaultAssetPickerBuilderDelegate
                               Positioned.fill(
                                 child: assetsGridBuilder(context),
                               ),
-                              if ((!isSingleAssetMode || isAppleOS) && isPreviewEnabled)
+                              if ((!isSingleAssetMode || isAppleOS) &&
+                                  isPreviewEnabled)
                                 PositionedDirectional(
                                   bottom: 0.0,
                                   child: bottomActionBar(context),
@@ -1155,6 +1159,36 @@ class DefaultAssetPickerBuilderDelegate
         );
         final bool selected = selectedAssets.contains(asset);
         final double indicatorSize = Screens.width / gridCount / 3;
+        final Widget innerSelector = AnimatedContainer(
+          duration: switchingPathDuration,
+          width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+          height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
+          decoration: BoxDecoration(
+            border:
+                !selected ? Border.all(color: Colors.white, width: 2.0) : null,
+            color: selected ? themeColor : null,
+            shape: BoxShape.circle,
+          ),
+          child: AnimatedSwitcher(
+            duration: switchingPathDuration,
+            reverseDuration: switchingPathDuration,
+            child: selected
+                ? isSingleAssetMode
+                    ? const Icon(Icons.check, size: 18.0)
+                    : Text(
+                        '${selectedAssets.indexOf(asset) + 1}',
+                        style: TextStyle(
+                          color: selected
+                              ? theme.textTheme.bodyText1?.color
+                              : null,
+                          fontSize: isAppleOS ? 16.0 : 14.0,
+                          fontWeight:
+                              isAppleOS ? FontWeight.w600 : FontWeight.bold,
+                        ),
+                      )
+                : const SizedBox.shrink(),
+          ),
+        );
         final GestureDetector selectorWidget = GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () {
@@ -1177,47 +1211,15 @@ class DefaultAssetPickerBuilderDelegate
             width: isPreviewEnabled ? indicatorSize : null,
             height: isPreviewEnabled ? indicatorSize : null,
             alignment: AlignmentDirectional.topEnd,
-            child: (!isPreviewEnabled && isSingleAssetMode && !selected) ? 
-              Container() :
-              AnimatedContainer(
-                duration: switchingPathDuration,
-                width: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-                height: indicatorSize / (isAppleOS ? 1.25 : 1.5),
-                decoration: BoxDecoration(
-                  border: !selected
-                      ? Border.all(color: Colors.white, width: 2.0)
-                      : null,
-                  color: selected ? themeColor : null,
-                  shape: BoxShape.circle,
-                ),
-                child: AnimatedSwitcher(
-                  duration: switchingPathDuration,
-                  reverseDuration: switchingPathDuration,
-                  child: selected
-                      ? isSingleAssetMode
-                          ? const Icon(Icons.check, size: 18.0)
-                          : Text(
-                              '${selectedAssets.indexOf(asset) + 1}',
-                              style: TextStyle(
-                                color: selected
-                                    ? theme.textTheme.bodyText1?.color
-                                    : null,
-                                fontSize: isAppleOS ? 16.0 : 14.0,
-                                fontWeight: isAppleOS
-                                    ? FontWeight.w600
-                                    : FontWeight.bold,
-                              ),
-                            )
-                      : const SizedBox.shrink(),
-                ),
-              ),
+            child: (!isPreviewEnabled && isSingleAssetMode && !selected)
+                ? const SizedBox.shrink()
+                : innerSelector,
           ),
         );
         if (isPreviewEnabled) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
-        } else {
-          return selectorWidget;
         }
+        return selectorWidget;
       },
     );
   }
@@ -1227,9 +1229,9 @@ class DefaultAssetPickerBuilderDelegate
     return Positioned.fill(
       child: GestureDetector(
         onTap: () async {
-          // While the special type is WeChat moment, picture and video cannot
+          // When the special type is WeChat Moment, pictures and videos cannot
           // be selected at the same time. Video select should be banned if any
-          // picture is selected.
+          // pictures are selected.
           if (specialPickerType == SpecialPickerType.wechatMoment &&
               asset.type == AssetType.video &&
               provider.selectedAssets.isNotEmpty) {

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -474,6 +474,10 @@ class DefaultAssetPickerBuilderDelegate
   /// 切换路径时的动画曲线
   Curve get switchingPathCurve => Curves.easeInOut;
 
+  /// [bool] Does picker type enable preview.
+  /// 选择器类型是否启用预览
+  bool get isPreviewEnabled => specialPickerType != SpecialPickerType.noPreview;
+
   @override
   Widget androidLayout(BuildContext context) {
     return FixedAppBarWrapper(
@@ -494,7 +498,7 @@ class DefaultAssetPickerBuilderDelegate
                         child: Column(
                           children: <Widget>[
                             Expanded(child: assetsGridBuilder(context)),
-                            if (!isSingleAssetMode && specialPickerType != SpecialPickerType.noPreview) bottomActionBar(context),
+                            if (!isSingleAssetMode && isPreviewEnabled) bottomActionBar(context),
                           ],
                         ),
                       ),
@@ -516,7 +520,7 @@ class DefaultAssetPickerBuilderDelegate
       centerTitle: isAppleOS,
       title: pathEntitySelector(context),
       leading: backButton(context),
-      actions: !isAppleOS && ((specialPickerType != SpecialPickerType.noPreview) || !isSingleAssetMode) ? <Widget>[confirmButton(context)] : null,
+      actions: !isAppleOS && (isPreviewEnabled || !isSingleAssetMode) ? <Widget>[confirmButton(context)] : null,
       actionsPadding: const EdgeInsets.only(right: 14.0),
       blurRadius: isAppleOS ? appleOSBlurRadius : 0.0,
     );
@@ -540,7 +544,7 @@ class DefaultAssetPickerBuilderDelegate
                               Positioned.fill(
                                 child: assetsGridBuilder(context),
                               ),
-                              if ((!isSingleAssetMode || isAppleOS) && specialPickerType != SpecialPickerType.noPreview)
+                              if ((!isSingleAssetMode || isAppleOS) && isPreviewEnabled)
                                 PositionedDirectional(
                                   bottom: 0.0,
                                   child: bottomActionBar(context),
@@ -1161,7 +1165,7 @@ class DefaultAssetPickerBuilderDelegate
                 provider.selectedAssets.clear();
               }
               provider.selectAsset(asset);
-              if (isSingleAssetMode && specialPickerType == SpecialPickerType.noPreview) {
+              if (isSingleAssetMode && !isPreviewEnabled) {
                 Navigator.of(context).pop(provider.selectedAssets);
               }
             }
@@ -1170,10 +1174,10 @@ class DefaultAssetPickerBuilderDelegate
             margin: EdgeInsets.all(
               Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
             ),
-            width: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
-            height: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
+            width: isPreviewEnabled ? indicatorSize : null,
+            height: isPreviewEnabled ? indicatorSize : null,
             alignment: AlignmentDirectional.topEnd,
-            child: (specialPickerType == SpecialPickerType.noPreview && isSingleAssetMode && !selected) ? 
+            child: (!isPreviewEnabled && isSingleAssetMode && !selected) ? 
               Container() :
               AnimatedContainer(
                 duration: switchingPathDuration,
@@ -1209,7 +1213,7 @@ class DefaultAssetPickerBuilderDelegate
               ),
           ),
         );
-        if (specialPickerType != SpecialPickerType.noPreview) {
+        if (isPreviewEnabled) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
         } else {
           return selectorWidget;

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -474,7 +474,7 @@ class DefaultAssetPickerBuilderDelegate
   /// 切换路径时的动画曲线
   Curve get switchingPathCurve => Curves.easeInOut;
 
-  /// [bool] Whether the preview of assets is enabled.
+  /// Whether the preview of assets is enabled.
   /// 资源的预览是否启用
   bool get isPreviewEnabled => specialPickerType != SpecialPickerType.noPreview;
 

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -89,12 +89,12 @@ abstract class AssetPickerBuilderDelegate<A, P> {
   /// There're several types which are special:
   /// * [SpecialPickerType.wechatMoment] When user selected video, no more images
   /// can be selected.
-  /// * [SpecialPickerType.disablePreview] Disable preview of asset; Clicking on an
+  /// * [SpecialPickerType.noPreview] Disable preview of asset; Clicking on an
   /// asset selects it.
   ///
   /// 这里包含一些特殊选择类型：
   /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。当用户选择了视频，将不能选择图片。
-  /// * [SpecialPickerType.disablePreview] 禁用资产预览； 单击资产将其选中。
+  /// * [SpecialPickerType.noPreview] 禁用资产预览； 单击资产将其选中。
   final SpecialPickerType? specialPickerType;
 
   /// The [ScrollController] for the preview grid.
@@ -343,7 +343,7 @@ abstract class AssetPickerBuilderDelegate<A, P> {
       child: Row(children: <Widget>[
         if (!isSingleAssetMode || !isAppleOS) previewButton(context),
         if (isAppleOS) const Spacer(),
-        if (isAppleOS && ((specialPickerType != SpecialPickerType.disablePreview) || !isSingleAssetMode)) confirmButton(context),
+        if (isAppleOS && ((specialPickerType != SpecialPickerType.noPreview) || !isSingleAssetMode)) confirmButton(context),
       ]),
     );
     if (isAppleOS) {
@@ -496,7 +496,7 @@ class DefaultAssetPickerBuilderDelegate
                         child: Column(
                           children: <Widget>[
                             Expanded(child: assetsGridBuilder(context)),
-                            if (!isSingleAssetMode && specialPickerType != SpecialPickerType.disablePreview) bottomActionBar(context),
+                            if (!isSingleAssetMode && specialPickerType != SpecialPickerType.noPreview) bottomActionBar(context),
                           ],
                         ),
                       ),
@@ -518,7 +518,7 @@ class DefaultAssetPickerBuilderDelegate
       centerTitle: isAppleOS,
       title: pathEntitySelector(context),
       leading: backButton(context),
-      actions: !isAppleOS && ((specialPickerType != SpecialPickerType.disablePreview) || !isSingleAssetMode) ? <Widget>[confirmButton(context)] : null,
+      actions: !isAppleOS && ((specialPickerType != SpecialPickerType.noPreview) || !isSingleAssetMode) ? <Widget>[confirmButton(context)] : null,
       actionsPadding: const EdgeInsets.only(right: 14.0),
       blurRadius: isAppleOS ? appleOSBlurRadius : 0.0,
     );
@@ -542,7 +542,7 @@ class DefaultAssetPickerBuilderDelegate
                               Positioned.fill(
                                 child: assetsGridBuilder(context),
                               ),
-                              if ((!isSingleAssetMode || isAppleOS) && specialPickerType != SpecialPickerType.disablePreview)
+                              if ((!isSingleAssetMode || isAppleOS) && specialPickerType != SpecialPickerType.noPreview)
                                 PositionedDirectional(
                                   bottom: 0.0,
                                   child: bottomActionBar(context),
@@ -1163,7 +1163,7 @@ class DefaultAssetPickerBuilderDelegate
                 provider.selectedAssets.clear();
               }
               provider.selectAsset(asset);
-              if (isSingleAssetMode && specialPickerType == SpecialPickerType.disablePreview) {
+              if (isSingleAssetMode && specialPickerType == SpecialPickerType.noPreview) {
                 Navigator.of(context).pop(provider.selectedAssets);
               }
             }
@@ -1172,10 +1172,10 @@ class DefaultAssetPickerBuilderDelegate
             margin: EdgeInsets.all(
               Screens.width / gridCount / (isAppleOS ? 12.0 : 15.0),
             ),
-            width: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
-            height: specialPickerType != SpecialPickerType.disablePreview ? indicatorSize : null,
+            width: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
+            height: specialPickerType != SpecialPickerType.noPreview ? indicatorSize : null,
             alignment: AlignmentDirectional.topEnd,
-            child: (specialPickerType == SpecialPickerType.disablePreview && isSingleAssetMode && !selected) ? 
+            child: (specialPickerType == SpecialPickerType.noPreview && isSingleAssetMode && !selected) ? 
               Container() :
               AnimatedContainer(
                 duration: switchingPathDuration,
@@ -1211,7 +1211,7 @@ class DefaultAssetPickerBuilderDelegate
               ),
           ),
         );
-        if (specialPickerType != SpecialPickerType.disablePreview) {
+        if (specialPickerType != SpecialPickerType.noPreview) {
           return Positioned(top: 0.0, right: 0.0, child: selectorWidget);
         } else {
           return selectorWidget;

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -40,7 +40,6 @@ class AssetPicker<A, P> extends StatelessWidget {
     bool allowSpecialItemWhenEmpty = false,
     Curve routeCurve = Curves.easeIn,
     Duration routeDuration = const Duration(milliseconds: 300),
-    bool showPreview = true,
   }) async {
     if (maxAssets < 1) {
       throw ArgumentError(
@@ -103,7 +102,6 @@ class AssetPicker<A, P> extends StatelessWidget {
               specialItemBuilder: specialItemBuilder,
               loadingIndicatorBuilder: loadingIndicatorBuilder,
               allowSpecialItemWhenEmpty: allowSpecialItemWhenEmpty,
-              showPreview: showPreview,
             ),
           ),
         );

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -40,6 +40,7 @@ class AssetPicker<A, P> extends StatelessWidget {
     bool allowSpecialItemWhenEmpty = false,
     Curve routeCurve = Curves.easeIn,
     Duration routeDuration = const Duration(milliseconds: 300),
+    bool showPreview = true,
   }) async {
     if (maxAssets < 1) {
       throw ArgumentError(
@@ -102,6 +103,7 @@ class AssetPicker<A, P> extends StatelessWidget {
               specialItemBuilder: specialItemBuilder,
               loadingIndicatorBuilder: loadingIndicatorBuilder,
               allowSpecialItemWhenEmpty: allowSpecialItemWhenEmpty,
+              showPreview: showPreview,
             ),
           ),
         );

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -56,14 +56,13 @@ class AssetPicker<A, P> extends StatelessWidget {
         'Theme and theme color cannot be set at the same time.',
       );
     }
-    if (specialPickerType != null && requestType != RequestType.image) {
-      throw ArgumentError(
-        'specialPickerType and requestType cannot be set at the same time.',
-      );
-    } else {
-      if (specialPickerType == SpecialPickerType.wechatMoment) {
-        requestType = RequestType.common;
+    if (specialPickerType == SpecialPickerType.wechatMoment) {
+      if (requestType != RequestType.image) {
+        throw ArgumentError(
+          'SpecialPickerType.wechatMoment and requestType cannot be set at the same time.',
+        );
       }
+      requestType = RequestType.common;
     }
     if ((specialItemBuilder == null &&
             specialItemPosition != SpecialItemPosition.none) ||


### PR DESCRIPTION
Hi,

I have added a new flag called showPreview to AssetPicker.pickAssets.

Default behavior (default value of showPreview parameter is true) is identical to the behavior so far: if you click an asset, you will get a preview of it. If you click the small circle, you select the asset.
But if you provide showPreview with false, there is no option to show preview. Instead, click on an assert will either add it to selection (multi assets mode) or select it (single assets more). 
That behavior is closer to "mainstream" application which have an image picker integrated (Facebook, Whatsapp, Instgram, Megatok, etc..).

I hope you will find this PR interesting and worthy to integrate soon.

Thank you,
Yaniv