### PR TITLE
🐛 SpecialPickerType.noPreview: Confirm button is missing on iOS

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -526,7 +526,8 @@ class DefaultAssetPickerBuilderDelegate
       centerTitle: isAppleOS,
       title: pathEntitySelector(context),
       leading: backButton(context),
-      actions: !isAppleOS && (isPreviewEnabled || !isSingleAssetMode)
+      actions: (!isAppleOS || !isPreviewEnabled) &&
+              (isPreviewEnabled || !isSingleAssetMode)
           ? <Widget>[confirmButton(context)]
           : null,
       actionsPadding: const EdgeInsets.only(right: 14.0),

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -526,6 +526,13 @@ class DefaultAssetPickerBuilderDelegate
       centerTitle: isAppleOS,
       title: pathEntitySelector(context),
       leading: backButton(context),
+      // Condition for displaying the confirm button:
+      // - On Android, show if preview is enabled or if multi asset mode.
+      //   meaning: If no preview and single asset mode, do not show confirm button,
+      //   because any click on an asset selects it.
+      // - On iOS, show if no preview and multi asset mode; This is because for iOS
+      //   the bottomActionBar has the confirm button, but if no preview,
+      //   bottomActionBar isn't displayed.
       actions: (!isAppleOS || !isPreviewEnabled) &&
               (isPreviewEnabled || !isSingleAssetMode)
           ? <Widget>[confirmButton(context)]

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -528,11 +528,11 @@ class DefaultAssetPickerBuilderDelegate
       leading: backButton(context),
       // Condition for displaying the confirm button:
       // - On Android, show if preview is enabled or if multi asset mode.
-      //   meaning: If no preview and single asset mode, do not show confirm button,
+      //   If no preview and single asset mode, do not show confirm button,
       //   because any click on an asset selects it.
-      // - On iOS, show if no preview and multi asset mode; This is because for iOS
-      //   the bottomActionBar has the confirm button, but if no preview,
-      //   bottomActionBar isn't displayed.
+      // - On iOS, show if no preview and multi asset mode. This is because for iOS
+      //   the [bottomActionBar] has the confirm button, but if no preview,
+      //   [bottomActionBar] is not displayed.
       actions: (!isAppleOS || !isPreviewEnabled) &&
               (isPreviewEnabled || !isSingleAssetMode)
           ? <Widget>[confirmButton(context)]


### PR DESCRIPTION
For SpecialPickerType.noPreview, the confirm button is missing.
Show confirm button for iOS on app bar.
Note that using de morgan's law doesn't make the code any nicer, I think this is the best alternative.