### PR TITLE
[Exception fix] Missing scroller controller

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -258,6 +258,7 @@ abstract class AssetPickerBuilderDelegate<A, P> {
         selector: (_, AssetPickerProvider<A, P> provider) =>
             provider.currentAssets,
         builder: (_, List<A> currentAssets, __) => CustomScrollView(
+          controller: gridScrollController,
           slivers: <Widget>[
             if (isAppleOS)
               SliverPadding(


### PR DESCRIPTION
When changing folders, scroll controller is set to jump to 0 - but scroll controller was not used.