### PR TITLE
[Feature] Ability to open asset picker from the same position it was previously closed after confirming assets

### DIFF
--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -250,11 +250,11 @@ class PickMethod {
   static AssetPickerBuilderDelegate<AssetEntity, AssetPathEntity>? _delegate;
   static DefaultAssetPickerProvider? _provider;
 
-  static PickMethod savePage(int maxAssetsCount) {
+  static PickMethod savePosition(int maxAssetsCount) {
     return PickMethod(
       icon: '👁️‍🗨️',
-      name: 'With delegate',
-      description: 'Pick assets with delegate.',
+      name: 'Save position',
+      description: 'Pick assets from same scroll position.',
       method: (
         BuildContext context,
         List<AssetEntity> assets,

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -247,6 +247,45 @@ class PickMethod {
       },
     );
   }
+  static AssetPickerBuilderDelegate<AssetEntity, AssetPathEntity>? _delegate;
+  static DefaultAssetPickerProvider? _provider;
+
+  static PickMethod savePage(int maxAssetsCount) {
+    return PickMethod(
+      icon: '👁️‍🗨️',
+      name: 'With delegate',
+      description: 'Pick assets with delegate.',
+      method: (
+        BuildContext context,
+        List<AssetEntity> assets,
+      ) async {
+        _provider ??= DefaultAssetPickerProvider(
+          selectedAssets: assets,
+          requestType: RequestType.common,
+          maxAssets: maxAssetsCount,
+        );
+
+        if (_delegate == null) {
+          final PermissionState _ps =
+              await PhotoManager.requestPermissionExtend();
+          if (_ps != PermissionState.authorized &&
+              _ps != PermissionState.limited) {
+            throw StateError('Permission state error with $_ps.');
+          }
+          _delegate = DefaultAssetPickerBuilderDelegate(
+            provider: _provider!,
+            initialPermission: _ps,
+          );
+        }
+
+        return await AssetPicker.pickAssetsWithDelegate(
+          context,
+          delegate: _delegate!,
+          provider: _provider!,
+        );
+      },
+    );
+  }
 
   final String icon;
   final String name;

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -252,7 +252,7 @@ class PickMethod {
 
   static PickMethod savePosition(int maxAssetsCount) {
     return PickMethod(
-      icon: '👁️‍🗨️',
+      icon: '📜',
       name: 'Save position',
       description: 'Pick assets from same scroll position.',
       method: (

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -55,6 +55,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage>
         },
       ),
       PickMethod.noPreview(maxAssetsCount),
+      PickMethod.savePage(maxAssetsCount),
       PickMethod(
         icon: '🎚',
         name: 'Custom image preview thumb size',

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -55,7 +55,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage>
         },
       ),
       PickMethod.noPreview(maxAssetsCount),
-      PickMethod.savePage(maxAssetsCount),
+      PickMethod.savePosition(maxAssetsCount),
       PickMethod(
         icon: '🎚',
         name: 'Custom image preview thumb size',

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -92,6 +92,14 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   /// The [ScrollController] for the preview grid.
   final ScrollController gridScrollController = ScrollController();
 
+  /// [ScrollPosition] for resuming ScrollController position.
+  /// <zhongwen here>
+  ScrollPosition? _savedScrollPosition;
+
+  /// Whether dispose should be skipped for this delegate.
+  /// <zhongwen here>
+  bool skipDispose = false;
+
   /// The [GlobalKey] for [assetsGridBuilder] to locate the [ScrollView.center].
   /// [assetsGridBuilder] 用于定位 [ScrollView.center] 的 [GlobalKey]
   final GlobalKey gridRevertKey = GlobalKey();
@@ -559,6 +567,12 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   /// Yes, the build method.
   /// 没错，是它是它就是它，我们亲爱的 build 方法~
   Widget build(BuildContext context) {
+    if (_savedScrollPosition != null) {
+      // A frame after build is invoked, jump to the saved scroll position
+      WidgetsBinding.instance!.addPostFrameCallback((_) {
+        gridScrollController.jumpTo(_savedScrollPosition!.pixels);
+      });
+    }
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: overlayStyle,
       child: Theme(
@@ -1121,6 +1135,7 @@ class DefaultAssetPickerBuilderDelegate
           ),
           onPressed: () {
             if (provider.isSelectedNotEmpty) {
+              _savedScrollPosition = gridScrollController.position;
               Navigator.of(context).pop(provider.selectedAssets);
             }
           },

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -140,6 +140,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
     Duration routeDuration = const Duration(milliseconds: 300),
   }) async {
     await permissionCheck();
+    delegate.skipDispose = true;
 
     final Widget picker = ChangeNotifierProvider<PickerProvider>.value(
       value: provider,
@@ -261,7 +262,9 @@ class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
   void dispose() {
     WidgetsBinding.instance!.removeObserver(this);
     AssetPicker.unregisterObserve(_onLimitedAssetsUpdated);
-    widget.builder.dispose();
+    if (!widget.builder.skipDispose) {
+      widget.builder.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
Notes:
- Supported only with `pickAssetsWithDelegate`
- In order to use this, you must reuse the same provider and delegate
- The picker will be opened in the same scroll position it was previously closed on when confirming assets
- See example called `Save position`