### PR TITLE
Integrate iCloud progress overview in previews

### DIFF
--- a/lib/src/provider/asset_entity_image_provider.dart
+++ b/lib/src/provider/asset_entity_image_provider.dart
@@ -97,7 +97,7 @@ class AssetEntityImageProvider extends ImageProvider<AssetEntityImageProvider> {
       );
     }
     if (data == null) {
-      throw AssertionError('Null in entity\'s data.');
+      throw AssertionError('Null data in entity: $entity');
     }
     return decode(data);
   }

--- a/lib/src/widget/builder/image_page_builder.dart
+++ b/lib/src/widget/builder/image_page_builder.dart
@@ -34,8 +34,6 @@ class _ImagePageBuilderState extends State<ImagePageBuilder> {
   DefaultAssetPickerViewerBuilderDelegate get builder =>
       widget.state.builder as DefaultAssetPickerViewerBuilderDelegate;
 
-  bool _loaded = false;
-
   @override
   Widget build(BuildContext context) {
     return LocallyAvailableBuilder(
@@ -64,13 +62,10 @@ class _ImagePageBuilderState extends State<ImagePageBuilder> {
             );
           },
           loadStateChanged: (ExtendedImageState state) {
-            if (state.extendedImageLoadState == LoadState.completed) {
-              _loaded = true;
-            }
             return builder.previewWidgetLoadStateChanged(
               context,
               state,
-              hasLoaded: _loaded,
+              hasLoaded: state.extendedImageLoadState == LoadState.completed,
             );
           },
         ),

--- a/lib/src/widget/builder/image_page_builder.dart
+++ b/lib/src/widget/builder/image_page_builder.dart
@@ -38,38 +38,41 @@ class _ImagePageBuilderState extends State<ImagePageBuilder> {
   Widget build(BuildContext context) {
     return LocallyAvailableBuilder(
       asset: widget.asset,
-      builder: (BuildContext context) => GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: builder.switchDisplayingDetail,
-        child: ExtendedImage(
-          image: AssetEntityImageProvider(
-            widget.asset,
-            isOriginal: widget.previewThumbSize == null,
-            thumbSize: widget.previewThumbSize,
+      isOriginal: widget.previewThumbSize == null,
+      builder: (BuildContext context, AssetEntity asset) {
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: builder.switchDisplayingDetail,
+          child: ExtendedImage(
+            image: AssetEntityImageProvider(
+              asset,
+              isOriginal: widget.previewThumbSize == null,
+              thumbSize: widget.previewThumbSize,
+            ),
+            fit: BoxFit.contain,
+            mode: ExtendedImageMode.gesture,
+            onDoubleTap: builder.updateAnimation,
+            initGestureConfigHandler: (ExtendedImageState state) {
+              return GestureConfig(
+                initialScale: 1.0,
+                minScale: 1.0,
+                maxScale: 3.0,
+                animationMinScale: 0.6,
+                animationMaxScale: 4.0,
+                cacheGesture: false,
+                inPageView: true,
+              );
+            },
+            loadStateChanged: (ExtendedImageState state) {
+              return builder.previewWidgetLoadStateChanged(
+                context,
+                state,
+                hasLoaded: state.extendedImageLoadState == LoadState.completed,
+              );
+            },
           ),
-          fit: BoxFit.contain,
-          mode: ExtendedImageMode.gesture,
-          onDoubleTap: builder.updateAnimation,
-          initGestureConfigHandler: (ExtendedImageState state) {
-            return GestureConfig(
-              initialScale: 1.0,
-              minScale: 1.0,
-              maxScale: 3.0,
-              animationMinScale: 0.6,
-              animationMaxScale: 4.0,
-              cacheGesture: false,
-              inPageView: true,
-            );
-          },
-          loadStateChanged: (ExtendedImageState state) {
-            return builder.previewWidgetLoadStateChanged(
-              context,
-              state,
-              hasLoaded: state.extendedImageLoadState == LoadState.completed,
-            );
-          },
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/src/widget/builder/image_page_builder.dart
+++ b/lib/src/widget/builder/image_page_builder.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:extended_image/extended_image.dart';
 
 import '../../constants/constants.dart';
+import 'locally_available_builder.dart';
 
 class ImagePageBuilder extends StatefulWidget {
   const ImagePageBuilder({
@@ -33,43 +34,46 @@ class _ImagePageBuilderState extends State<ImagePageBuilder> {
   DefaultAssetPickerViewerBuilderDelegate get builder =>
       widget.state.builder as DefaultAssetPickerViewerBuilderDelegate;
 
-  bool loaded = false;
+  bool _loaded = false;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: builder.switchDisplayingDetail,
-      child: ExtendedImage(
-        image: AssetEntityImageProvider(
-          widget.asset,
-          isOriginal: widget.previewThumbSize == null,
-          thumbSize: widget.previewThumbSize,
+    return LocallyAvailableBuilder(
+      asset: widget.asset,
+      builder: (BuildContext context) => GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: builder.switchDisplayingDetail,
+        child: ExtendedImage(
+          image: AssetEntityImageProvider(
+            widget.asset,
+            isOriginal: widget.previewThumbSize == null,
+            thumbSize: widget.previewThumbSize,
+          ),
+          fit: BoxFit.contain,
+          mode: ExtendedImageMode.gesture,
+          onDoubleTap: builder.updateAnimation,
+          initGestureConfigHandler: (ExtendedImageState state) {
+            return GestureConfig(
+              initialScale: 1.0,
+              minScale: 1.0,
+              maxScale: 3.0,
+              animationMinScale: 0.6,
+              animationMaxScale: 4.0,
+              cacheGesture: false,
+              inPageView: true,
+            );
+          },
+          loadStateChanged: (ExtendedImageState state) {
+            if (state.extendedImageLoadState == LoadState.completed) {
+              _loaded = true;
+            }
+            return builder.previewWidgetLoadStateChanged(
+              context,
+              state,
+              hasLoaded: _loaded,
+            );
+          },
         ),
-        fit: BoxFit.contain,
-        mode: ExtendedImageMode.gesture,
-        onDoubleTap: builder.updateAnimation,
-        initGestureConfigHandler: (ExtendedImageState state) {
-          return GestureConfig(
-            initialScale: 1.0,
-            minScale: 1.0,
-            maxScale: 3.0,
-            animationMinScale: 0.6,
-            animationMaxScale: 4.0,
-            cacheGesture: false,
-            inPageView: true,
-          );
-        },
-        loadStateChanged: (ExtendedImageState state) {
-          if (state.extendedImageLoadState == LoadState.completed) {
-            loaded = true;
-          }
-          return builder.previewWidgetLoadStateChanged(
-            context,
-            state,
-            hasLoaded: loaded,
-          );
-        },
       ),
     );
   }

--- a/lib/src/widget/builder/locally_available_builder.dart
+++ b/lib/src/widget/builder/locally_available_builder.dart
@@ -1,0 +1,97 @@
+///
+/// [Author] Alex (https://github.com/AlexV525)
+/// [Date] 2021/7/23 16:07
+///
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import '../../constants/extensions.dart';
+import '../scale_text.dart';
+
+class LocallyAvailableBuilder extends StatefulWidget {
+  const LocallyAvailableBuilder({
+    Key? key,
+    required this.asset,
+    required this.builder,
+  }) : super(key: key);
+
+  final AssetEntity asset;
+  final WidgetBuilder builder;
+
+  @override
+  _LocallyAvailableBuilderState createState() =>
+      _LocallyAvailableBuilderState();
+}
+
+class _LocallyAvailableBuilderState extends State<LocallyAvailableBuilder> {
+  bool _isLocallyAvailable = false;
+  PMProgressHandler? _progressHandler;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkLocallyAvailable();
+  }
+
+  Future<void> _checkLocallyAvailable() async {
+    _isLocallyAvailable = await widget.asset.isLocallyAvailable;
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+    _progressHandler?.stream.listen((PMProgressState s) {
+      if (s.state == PMRequestState.success) {
+        _isLocallyAvailable = true;
+        if (mounted) {
+          setState(() {});
+        }
+      }
+    });
+  }
+
+  Widget _indicator(BuildContext context) {
+    return StreamBuilder<PMProgressState>(
+      stream: _progressHandler!.stream,
+      initialData: PMProgressState(0, PMRequestState.prepare),
+      builder: (BuildContext c, AsyncSnapshot<PMProgressState> s) {
+        if (s.hasData) {
+          final double progress = s.data!.progress;
+          final PMRequestState state = s.data!.state;
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                state == PMRequestState.failed
+                    ? Icons.cloud_off
+                    : Icons.cloud_queue,
+                color: context.themeData.iconTheme.color?.withOpacity(.4),
+                size: 28,
+              ),
+              if (state != PMRequestState.success &&
+                  state != PMRequestState.failed)
+                ScaleText(
+                  '  iCloud ${(progress * 100).toInt()}%',
+                  style: TextStyle(
+                    color: context.themeData.textTheme.bodyText2?.color
+                        ?.withOpacity(.4),
+                  ),
+                ),
+            ],
+          );
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLocallyAvailable) {
+      return widget.builder(context);
+    }
+    if (_progressHandler != null) {
+      return Center(child: _indicator(context));
+    }
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/widget/builder/video_page_builder.dart
+++ b/lib/src/widget/builder/video_page_builder.dart
@@ -139,7 +139,7 @@ class _VideoPageBuilderState extends State<VideoPageBuilder> {
   Widget build(BuildContext context) {
     return LocallyAvailableBuilder(
       asset: widget.asset,
-      builder: (BuildContext context) {
+      builder: (BuildContext context, AssetEntity asset) {
         if (hasErrorWhenInitializing) {
           return Center(child: ScaleText(Constants.textDelegate.loadFailed));
         }

--- a/lib/src/widget/builder/video_page_builder.dart
+++ b/lib/src/widget/builder/video_page_builder.dart
@@ -7,6 +7,7 @@ import 'package:video_player/video_player.dart';
 
 import '../../constants/constants.dart';
 import '../scale_text.dart';
+import 'locally_available_builder.dart';
 
 class VideoPageBuilder extends StatefulWidget {
   const VideoPageBuilder({
@@ -136,61 +137,63 @@ class _VideoPageBuilderState extends State<VideoPageBuilder> {
 
   @override
   Widget build(BuildContext context) {
-    if (hasErrorWhenInitializing) {
-      return Center(
-        child: ScaleText(
-          Constants.textDelegate.loadFailed,
-        ),
-      );
-    }
-    if (!hasLoaded) {
-      return const SizedBox.shrink();
-    }
-    return Stack(
-      fit: StackFit.expand,
-      children: <Widget>[
-        Positioned.fill(
-          child: Center(
-            child: AspectRatio(
-              aspectRatio: _controller.value.aspectRatio,
-              child: VideoPlayer(_controller),
-            ),
-          ),
-        ),
-        if (!widget.hasOnlyOneVideoAndMoment)
-          ValueListenableBuilder<bool>(
-            valueListenable: isPlaying,
-            builder: (_, bool value, __) => GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap:
-                  value ? playButtonCallback : builder.switchDisplayingDetail,
+    return LocallyAvailableBuilder(
+      asset: widget.asset,
+      builder: (BuildContext context) {
+        if (hasErrorWhenInitializing) {
+          return Center(child: ScaleText(Constants.textDelegate.loadFailed));
+        }
+        if (!hasLoaded) {
+          return const SizedBox.shrink();
+        }
+        return Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            Positioned.fill(
               child: Center(
-                child: AnimatedOpacity(
-                  duration: kThemeAnimationDuration,
-                  opacity: value ? 0.0 : 1.0,
-                  child: GestureDetector(
-                    onTap: playButtonCallback,
-                    child: DecoratedBox(
-                      decoration: const BoxDecoration(
-                        boxShadow: <BoxShadow>[
-                          BoxShadow(color: Colors.black12)
-                        ],
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(
-                        value
-                            ? Icons.pause_circle_outline
-                            : Icons.play_circle_filled,
-                        size: 70.0,
-                        color: Colors.white,
+                child: AspectRatio(
+                  aspectRatio: _controller.value.aspectRatio,
+                  child: VideoPlayer(_controller),
+                ),
+              ),
+            ),
+            if (!widget.hasOnlyOneVideoAndMoment)
+              ValueListenableBuilder<bool>(
+                valueListenable: isPlaying,
+                builder: (_, bool value, __) => GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: value
+                      ? playButtonCallback
+                      : builder.switchDisplayingDetail,
+                  child: Center(
+                    child: AnimatedOpacity(
+                      duration: kThemeAnimationDuration,
+                      opacity: value ? 0.0 : 1.0,
+                      child: GestureDetector(
+                        onTap: playButtonCallback,
+                        child: DecoratedBox(
+                          decoration: const BoxDecoration(
+                            boxShadow: <BoxShadow>[
+                              BoxShadow(color: Colors.black12)
+                            ],
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            value
+                                ? Icons.pause_circle_outline
+                                : Icons.play_circle_filled,
+                            size: 70.0,
+                            color: Colors.white,
+                          ),
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ),
-      ],
+          ],
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
     sdk: flutter
 
   extended_image: ^4.1.0
-  photo_manager: ^1.2.6+1
+  photo_manager: ^1.2.8
   provider: ^5.0.0
   video_player: ^2.1.6


### PR DESCRIPTION
Now that `photo_manager` supports checking whether the asset is locally available using the `Future` getter `AssetEntity.isLocallyAvailable`, so we can smoothly integrate the iCloud feature along with the `PMProgressHandler`.

This feature should be only involved with iOS and iCloud assets.

Related to #83 .

![image](https://user-images.githubusercontent.com/15884415/126758319-3c1caf58-15a0-4d3b-86df-e41753455658.png)
