### PR TITLE
[Localization] Inline text into text delegate

### DIFF
--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -782,7 +782,7 @@ class FileAssetPickerBuilder
         selector: (_, FileAssetPickerProvider p) => p.isAssetsEmpty,
         builder: (_, bool isAssetsEmpty, __) {
           if (isAssetsEmpty) {
-            return const Text('Nothing here.');
+            return Text(textDelegate.emptyList);
           } else {
             return Center(
               child: SizedBox.fromSize(

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -311,7 +311,8 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
             return loadingIndicatorBuilder!(c, isAssetsEmpty);
           }
           if (isAssetsEmpty) {
-            return const ScaleText('Nothing here.', maxScaleFactor: 1.5);
+            return ScaleText(Constants.textDelegate.emptyList,
+                maxScaleFactor: 1.5);
           }
           return w!;
         },
@@ -1219,7 +1220,8 @@ class DefaultAssetPickerBuilderDelegate
         selector: (_, DefaultAssetPickerProvider p) => p.isAssetsEmpty,
         builder: (_, bool isAssetsEmpty, __) {
           if (isAssetsEmpty) {
-            return const ScaleText('Nothing here.', maxScaleFactor: 1.5);
+            return ScaleText(Constants.textDelegate.emptyList,
+                maxScaleFactor: 1.5);
           }
           return PlatformProgressIndicator(
             color: theme.iconTheme.color,

--- a/lib/src/delegates/assets_picker_text_delegate.dart
+++ b/lib/src/delegates/assets_picker_text_delegate.dart
@@ -42,6 +42,10 @@ class AssetsPickerTextDelegate {
   /// 选择按钮的字段
   String get select => '选择';
 
+  /// Empty list string for empty asset list.
+  /// 空資產列表的空列表字符串
+  String get emptyList => '空列表';
+
   /// Un-supported asset type string for assets that belongs to [AssetType.other].
   /// 未支持的资源类型的字段
   String get unSupportedAssetType => '尚未支持的资源类型';
@@ -108,6 +112,9 @@ class EnglishTextDelegate extends AssetsPickerTextDelegate {
   String get select => 'Select';
 
   @override
+  String get emptyList => 'Empty list';
+
+  @override
   String get unSupportedAssetType => 'Unsupported HEIC asset type.';
 
   @override
@@ -164,6 +171,9 @@ class HebrewTextDelegate extends AssetsPickerTextDelegate {
 
   @override
   String get select => 'בחר';
+
+  @override
+  String get emptyList => 'הרשימה ריקה';
 
   @override
   String get unSupportedAssetType => 'סוג קובץ HEIC אינו נתמך';
@@ -223,6 +233,9 @@ class GermanTextDelegate extends AssetsPickerTextDelegate {
   String get select => 'Auswählen';
 
   @override
+  String get emptyList => 'Leere Liste';
+
+  @override
   String get unSupportedAssetType => 'HEIC Format ist nicht unterstützt.';
 
   @override
@@ -277,6 +290,9 @@ class RussianTextDelegate extends AssetsPickerTextDelegate {
 
   @override
   String get select => 'Выбрать';
+
+  @override
+  String get emptyList => 'Пустой список';
 
   @override
   String get unSupportedAssetType => 'Неподдерживаемый формат ресурса.';
@@ -338,6 +354,9 @@ class JapaneseTextDelegate extends AssetsPickerTextDelegate {
   String get select => '選択';
 
   @override
+  String get emptyList => '空のリスト';
+
+  @override
   String get unSupportedAssetType => 'HEIC フォーマットはサポートしていません。';
 
   @override
@@ -394,6 +413,9 @@ class ArabicTextDelegate extends AssetsPickerTextDelegate {
 
   @override
   String get select => 'تحديد';
+
+  @override
+  String get emptyList => 'قائمة فارغة';
 
   @override
   String get unSupportedAssetType => 'نوع HEIC غير مدعوم';


### PR DESCRIPTION
'Nothing here' text moved into text delegate and changed to 'Empty list'.
For Chinese, Japanese and German I have used google translate - they have to be refined.