### PR TITLE
🎨 Improve audio item layout

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1174,7 +1174,7 @@ class DefaultAssetPickerBuilderDelegate
           ),
         ),
         const Align(
-          alignment: Alignment.bottomRight,
+          alignment: AlignmentDirectional.bottomEnd,
           child: Padding(
             padding: EdgeInsetsDirectional.only(end: 4, bottom: 8),
             child: Icon(Icons.audiotrack),

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1173,7 +1173,13 @@ class DefaultAssetPickerBuilderDelegate
             ),
           ),
         ),
-        const Align(alignment: AlignmentDirectional.bottomEnd, child: Icon(Icons.audiotrack)),
+        const Align(
+          alignment: AlignmentDirectional.bottomEnd,
+          child: Padding(
+            padding: EdgeInsetsDirectional.only(end: 4, bottom: 8),
+            child: Icon(Icons.audiotrack),
+          ),
+        ),
         audioIndicator(context, asset),
       ],
     );

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1168,12 +1168,12 @@ class DefaultAssetPickerBuilderDelegate
             child: ScaleText(
               asset.title ?? '',
               style: const TextStyle(fontSize: 16),
-              maxLines: 1,
+              maxLines: 3,
               overflow: TextOverflow.ellipsis,
             ),
           ),
         ),
-        const Center(child: Icon(Icons.audiotrack)),
+        const Align(alignment: AlignmentDirectional.bottomEnd, child: Icon(Icons.audiotrack)),
         audioIndicator(context, asset),
       ],
     );

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1174,11 +1174,8 @@ class DefaultAssetPickerBuilderDelegate
           ),
         ),
         const Align(
-          alignment: AlignmentDirectional.bottomEnd,
-          child: Padding(
-            padding: EdgeInsetsDirectional.only(end: 4, bottom: 8),
-            child: Icon(Icons.audiotrack),
-          ),
+          alignment: AlignmentDirectional(0.9, 0.8),
+          child: Icon(Icons.audiotrack),
         ),
         audioIndicator(context, asset),
       ],

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1174,7 +1174,7 @@ class DefaultAssetPickerBuilderDelegate
           ),
         ),
         const Align(
-          alignment: AlignmentDirectional.bottomEnd,
+          alignment: Alignment.bottomRight,
           child: Padding(
             padding: EdgeInsetsDirectional.only(end: 4, bottom: 8),
             child: Icon(Icons.audiotrack),


### PR DESCRIPTION
With current display, file name is cut, most of the real estate is used by the audio track symbol:

<img src="https://user-images.githubusercontent.com/13107481/143002050-bbee48da-34bf-4463-bebe-51a2285e4288.png" width="248">
Suggesting to use 3 lines for the filename, moving the audio track next to the duration:

<img src="https://user-images.githubusercontent.com/13107481/143002251-70442f20-d116-4ee6-b2ea-33af87df365a.png" width="248">
