### PR TITLE
⚡ Improve text delegate

### DIFF
--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -292,7 +292,7 @@ class PickMethod {
           context,
           maxAssets: maxAssetsCount,
           selectedAssets: assets,
-          textDelegate: EnglishTextDelegate(),
+          textDelegate: EnglishAssetPickerTextDelegate(),
         );
       },
     );

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -81,9 +81,9 @@ class PickMethod {
           specialItemPosition: SpecialItemPosition.prepend,
           specialItemBuilder: (BuildContext context) {
             return Semantics(
-              label: AssetsPickerTextDelegate().sActionUseCameraHint,
+              label: AssetPickerTextDelegate().sActionUseCameraHint,
               button: true,
-              onTapHint: AssetsPickerTextDelegate().sActionUseCameraHint,
+              onTapHint: AssetPickerTextDelegate().sActionUseCameraHint,
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: () async {
@@ -122,9 +122,9 @@ class PickMethod {
           specialItemPosition: SpecialItemPosition.prepend,
           specialItemBuilder: (BuildContext context) {
             return Semantics(
-              label: AssetsPickerTextDelegate().sActionUseCameraHint,
+              label: AssetPickerTextDelegate().sActionUseCameraHint,
               button: true,
-              onTapHint: AssetsPickerTextDelegate().sActionUseCameraHint,
+              onTapHint: AssetPickerTextDelegate().sActionUseCameraHint,
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: () async {

--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -45,12 +45,13 @@ class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker>
 
   ThemeData get currentTheme => Theme.of(context);
 
-  Future<void> callPicker() async {
+  Future<void> callPicker(BuildContext context) async {
     final FileAssetPickerProvider provider = FileAssetPickerProvider(
       selectedAssets: fileList,
     );
     final FileAssetPickerBuilder builder = FileAssetPickerBuilder(
       provider: provider,
+      locale: Localizations.maybeLocaleOf(context),
     );
     final List<File>? result = await AssetPicker.pickAssetsWithDelegate(
       context,
@@ -279,7 +280,7 @@ class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker>
                     'Put files into the path to see how this custom picker work.',
                   ),
                   TextButton(
-                    onPressed: callPicker,
+                    onPressed: () => callPicker(context),
                     child: const Text(
                       '🎁 Call the Picker',
                       style: TextStyle(fontSize: 22),
@@ -377,7 +378,12 @@ class FileAssetPickerBuilder
     extends AssetPickerBuilderDelegate<File, Directory> {
   FileAssetPickerBuilder({
     required FileAssetPickerProvider provider,
-  }) : super(provider: provider, initialPermission: PermissionState.authorized);
+    Locale? locale,
+  }) : super(
+          provider: provider,
+          initialPermission: PermissionState.authorized,
+          locale: locale,
+        );
 
   Duration get switchingPathDuration => kThemeAnimationDuration * 1.5;
 

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -7,7 +7,7 @@ import 'dart:developer';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../delegates/assets_picker_text_delegate.dart';
+import '../delegates/asset_picker_text_delegate.dart';
 import '../delegates/sort_path_delegate.dart';
 
 class Constants {
@@ -15,7 +15,7 @@ class Constants {
 
   static GlobalKey pickerKey = GlobalKey();
 
-  static AssetsPickerTextDelegate textDelegate = AssetsPickerTextDelegate();
+  static AssetPickerTextDelegate textDelegate = AssetPickerTextDelegate();
   static SortPathDelegate<dynamic> sortPathDelegate = SortPathDelegate.common;
 
   /// The last scroll position where the picker scrolled.

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -74,7 +74,8 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
         ),
         themeColor =
             pickerTheme?.colorScheme.secondary ?? themeColor ?? C.themeColor {
-    Constants.textDelegate = textDelegate ?? _textDelegateWithLocale(locale);
+    Constants.textDelegate =
+        textDelegate ?? assetPickerTextDelegateFromLocale(locale);
     // Add the listener if [keepScrollOffset] is true.
     if (keepScrollOffset) {
       gridScrollController.addListener(keepScrollOffsetListener);
@@ -677,26 +678,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
         ),
       ),
     );
-  }
-
-  static AssetPickerTextDelegate _textDelegateWithLocale(Locale? locale) {
-    switch (locale?.languageCode.toLowerCase()) {
-      case 'en':
-        return EnglishAssetPickerTextDelegate();
-      case 'he':
-        return HebrewAssetPickerTextDelegate();
-      case 'de':
-        return GermanAssetPickerTextDelegate();
-      case 'ru':
-        return RussianAssetPickerTextDelegate();
-      case 'ja':
-        return JapaneseAssetPickerTextDelegate();
-      case 'ar':
-        return ArabicAssetPickerTextDelegate();
-      case 'fr':
-        return FrenchAssetPickerTextDelegate();
-    }
-    return AssetPickerTextDelegate();
   }
 }
 

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -20,7 +20,7 @@ import '../constants/colors.dart';
 import '../constants/constants.dart';
 import '../constants/enums.dart';
 import '../constants/extensions.dart';
-import '../delegates/assets_picker_text_delegate.dart';
+import '../delegates/asset_picker_text_delegate.dart';
 import '../provider/asset_picker_provider.dart';
 import '../widget/asset_picker.dart';
 import '../widget/asset_picker_viewer.dart';
@@ -57,8 +57,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     required this.provider,
     required this.initialPermission,
     this.gridCount = 4,
-    Color? themeColor,
-    AssetsPickerTextDelegate? textDelegate,
     this.pickerTheme,
     this.specialItemPosition = SpecialItemPosition.none,
     this.specialItemBuilder,
@@ -67,13 +65,15 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     this.keepScrollOffset = false,
     this.selectPredicate,
     this.shouldRevertGrid,
+    Color? themeColor,
+    AssetPickerTextDelegate? textDelegate,
   })  : assert(
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
         ),
         themeColor =
             pickerTheme?.colorScheme.secondary ?? themeColor ?? C.themeColor {
-    Constants.textDelegate = textDelegate ?? AssetsPickerTextDelegate();
+    Constants.textDelegate = textDelegate ?? AssetPickerTextDelegate();
     // Add the listener if [keepScrollOffset] is true.
     if (keepScrollOffset) {
       gridScrollController.addListener(keepScrollOffsetListener);
@@ -212,7 +212,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
 
   bool get effectiveShouldRevertGrid => shouldRevertGrid ?? isAppleOS;
 
-  AssetsPickerTextDelegate get textDelegate => Constants.textDelegate;
+  AssetPickerTextDelegate get textDelegate => Constants.textDelegate;
 
   /// The listener to track the scroll position of the [gridScrollController]
   /// if [keepScrollOffset] is true.
@@ -686,7 +686,7 @@ class DefaultAssetPickerBuilderDelegate
     required PermissionState initialPermission,
     int gridCount = 4,
     Color? themeColor,
-    AssetsPickerTextDelegate? textDelegate,
+    AssetPickerTextDelegate? textDelegate,
     ThemeData? pickerTheme,
     SpecialItemPosition specialItemPosition = SpecialItemPosition.none,
     WidgetBuilder? specialItemBuilder,

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -67,13 +67,14 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     this.shouldRevertGrid,
     Color? themeColor,
     AssetPickerTextDelegate? textDelegate,
+    Locale? locale,
   })  : assert(
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
         ),
         themeColor =
             pickerTheme?.colorScheme.secondary ?? themeColor ?? C.themeColor {
-    Constants.textDelegate = textDelegate ?? AssetPickerTextDelegate();
+    Constants.textDelegate = textDelegate ?? _textDelegateWithLocale(locale);
     // Add the listener if [keepScrollOffset] is true.
     if (keepScrollOffset) {
       gridScrollController.addListener(keepScrollOffsetListener);
@@ -677,6 +678,26 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       ),
     );
   }
+
+  static AssetPickerTextDelegate _textDelegateWithLocale(Locale? locale) {
+    switch (locale?.languageCode.toLowerCase()) {
+      case 'en':
+        return EnglishAssetPickerTextDelegate();
+      case 'he':
+        return HebrewAssetPickerTextDelegate();
+      case 'de':
+        return GermanAssetPickerTextDelegate();
+      case 'ru':
+        return RussianAssetPickerTextDelegate();
+      case 'ja':
+        return JapaneseAssetPickerTextDelegate();
+      case 'ar':
+        return ArabicAssetPickerTextDelegate();
+      case 'fr':
+        return FrenchAssetPickerTextDelegate();
+    }
+    return AssetPickerTextDelegate();
+  }
 }
 
 class DefaultAssetPickerBuilderDelegate
@@ -685,8 +706,6 @@ class DefaultAssetPickerBuilderDelegate
     required DefaultAssetPickerProvider provider,
     required PermissionState initialPermission,
     int gridCount = 4,
-    Color? themeColor,
-    AssetPickerTextDelegate? textDelegate,
     ThemeData? pickerTheme,
     SpecialItemPosition specialItemPosition = SpecialItemPosition.none,
     WidgetBuilder? specialItemBuilder,
@@ -698,6 +717,9 @@ class DefaultAssetPickerBuilderDelegate
     this.gridThumbSize = Constants.defaultGridThumbSize,
     this.previewThumbSize,
     this.specialPickerType,
+    Color? themeColor,
+    AssetPickerTextDelegate? textDelegate,
+    Locale? locale,
   })  : assert(
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
@@ -706,8 +728,6 @@ class DefaultAssetPickerBuilderDelegate
           provider: provider,
           initialPermission: initialPermission,
           gridCount: gridCount,
-          themeColor: themeColor,
-          textDelegate: textDelegate,
           pickerTheme: pickerTheme,
           specialItemPosition: specialItemPosition,
           specialItemBuilder: specialItemBuilder,
@@ -716,6 +736,9 @@ class DefaultAssetPickerBuilderDelegate
           keepScrollOffset: keepScrollOffset,
           selectPredicate: selectPredicate,
           shouldRevertGrid: shouldRevertGrid,
+          themeColor: themeColor,
+          textDelegate: textDelegate,
+          locale: locale,
         );
 
   /// Thumbnail size in the grid.

--- a/lib/src/delegates/asset_picker_text_delegate.dart
+++ b/lib/src/delegates/asset_picker_text_delegate.dart
@@ -81,7 +81,7 @@ class AssetPickerTextDelegate {
   /// Semantics fields.
   ///
   /// Fields below are only for semantics usage. For customizable these fields,
-  /// head over to [EnglishTextDelegate] for fields understanding.
+  /// head over to [EnglishAssetPickerTextDelegate] for fields understanding.
 
   String get sTypeAudioLabel => '音频';
 
@@ -121,7 +121,7 @@ class AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with English.
 /// English Localization
-class EnglishTextDelegate extends AssetPickerTextDelegate {
+class EnglishAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Confirm';
 
@@ -212,7 +212,7 @@ class EnglishTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with Hebrew.
 /// תרגום בשפה העברית
-class HebrewTextDelegate extends AssetPickerTextDelegate {
+class HebrewAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'אישור';
 
@@ -269,7 +269,7 @@ class HebrewTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implementiert mit der deutschen Übersetzung.
 /// Deutsche Textimplementierung.
-class GermanTextDelegate extends AssetPickerTextDelegate {
+class GermanAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Bestätigen';
 
@@ -325,7 +325,7 @@ class GermanTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with Russian.
 /// Локализация на русский язык.
-class RussianTextDelegate extends AssetPickerTextDelegate {
+class RussianAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Готово';
 
@@ -384,7 +384,7 @@ class RussianTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with Japanese.
 /// 日本語の TextDelegate
-class JapaneseTextDelegate extends AssetPickerTextDelegate {
+class JapaneseAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => '決定';
 
@@ -442,7 +442,7 @@ class JapaneseTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with Arabic.
 /// الترجمة العربية
-class ArabicTextDelegate extends AssetPickerTextDelegate {
+class ArabicAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'تاكيد';
 
@@ -501,7 +501,7 @@ class ArabicTextDelegate extends AssetPickerTextDelegate {
 
 /// [AssetPickerTextDelegate] implements with French.
 /// Délégué texte français
-class FrenchTextDelegate extends AssetPickerTextDelegate {
+class FrenchAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'OK';
 

--- a/lib/src/delegates/asset_picker_text_delegate.dart
+++ b/lib/src/delegates/asset_picker_text_delegate.dart
@@ -2,7 +2,6 @@
 /// [Author] Alex (https://github.com/Alex525)
 /// [Date] 2020/4/7 10:25
 ///
-import 'package:collection/collection.dart';
 import 'package:flutter/rendering.dart';
 import 'package:photo_manager/photo_manager.dart' show AssetType;
 
@@ -21,12 +20,16 @@ final List<AssetPickerTextDelegate> assetPickerTextDelegates =
 
 /// Obtain the text delegate from the given locale.
 AssetPickerTextDelegate assetPickerTextDelegateFromLocale(Locale? locale) {
-  final AssetPickerTextDelegate? match =
-      assetPickerTextDelegates.singleWhereOrNull(
-    (AssetPickerTextDelegate e) =>
-        e.languageCode == locale?.languageCode.toLowerCase(),
-  );
-  return match ?? AssetPickerTextDelegate();
+  if (locale == null) {
+    return AssetPickerTextDelegate();
+  }
+  final String languageCode = locale.languageCode.toLowerCase();
+  for (final AssetPickerTextDelegate delegate in assetPickerTextDelegates) {
+    if (delegate.languageCode == languageCode) {
+      return delegate;
+    }
+  }
+  return AssetPickerTextDelegate();
 }
 
 /// Text delegate that controls text in widgets.

--- a/lib/src/delegates/asset_picker_text_delegate.dart
+++ b/lib/src/delegates/asset_picker_text_delegate.dart
@@ -2,11 +2,38 @@
 /// [Author] Alex (https://github.com/Alex525)
 /// [Date] 2020/4/7 10:25
 ///
+import 'package:collection/collection.dart';
+import 'package:flutter/rendering.dart';
 import 'package:photo_manager/photo_manager.dart' show AssetType;
+
+/// All text delegates.
+final List<AssetPickerTextDelegate> assetPickerTextDelegates =
+    <AssetPickerTextDelegate>[
+  AssetPickerTextDelegate(),
+  EnglishAssetPickerTextDelegate(),
+  HebrewAssetPickerTextDelegate(),
+  GermanAssetPickerTextDelegate(),
+  RussianAssetPickerTextDelegate(),
+  JapaneseAssetPickerTextDelegate(),
+  ArabicAssetPickerTextDelegate(),
+  FrenchAssetPickerTextDelegate(),
+];
+
+/// Obtain the text delegate from the given locale.
+AssetPickerTextDelegate assetPickerTextDelegateFromLocale(Locale? locale) {
+  final AssetPickerTextDelegate? match =
+      assetPickerTextDelegates.singleWhereOrNull(
+    (AssetPickerTextDelegate e) =>
+        e.languageCode == locale?.languageCode.toLowerCase(),
+  );
+  return match ?? AssetPickerTextDelegate();
+}
 
 /// Text delegate that controls text in widgets.
 /// 控制部件中的文字实现
 class AssetPickerTextDelegate {
+  String get languageCode => 'zh';
+
   /// Confirm string for the confirm button.
   /// 确认按钮的字段
   String get confirm => '确认';
@@ -123,6 +150,9 @@ class AssetPickerTextDelegate {
 /// English Localization
 class EnglishAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
+  String get languageCode => 'en';
+
+  @override
   String get confirm => 'Confirm';
 
   @override
@@ -214,6 +244,9 @@ class EnglishAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// תרגום בשפה העברית
 class HebrewAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
+  String get languageCode => 'he';
+
+  @override
   String get confirm => 'אישור';
 
   @override
@@ -271,6 +304,9 @@ class HebrewAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// Deutsche Textimplementierung.
 class GermanAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
+  String get languageCode => 'de';
+
+  @override
   String get confirm => 'Bestätigen';
 
   @override
@@ -326,6 +362,9 @@ class GermanAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// [AssetPickerTextDelegate] implements with Russian.
 /// Локализация на русский язык.
 class RussianAssetPickerTextDelegate extends AssetPickerTextDelegate {
+  @override
+  String get languageCode => 'ru';
+
   @override
   String get confirm => 'Готово';
 
@@ -386,6 +425,9 @@ class RussianAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// 日本語の TextDelegate
 class JapaneseAssetPickerTextDelegate extends AssetPickerTextDelegate {
   @override
+  String get languageCode => 'ja';
+
+  @override
   String get confirm => '決定';
 
   @override
@@ -443,6 +485,9 @@ class JapaneseAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// [AssetPickerTextDelegate] implements with Arabic.
 /// الترجمة العربية
 class ArabicAssetPickerTextDelegate extends AssetPickerTextDelegate {
+  @override
+  String get languageCode => 'ar';
+
   @override
   String get confirm => 'تاكيد';
 
@@ -502,6 +547,9 @@ class ArabicAssetPickerTextDelegate extends AssetPickerTextDelegate {
 /// [AssetPickerTextDelegate] implements with French.
 /// Délégué texte français
 class FrenchAssetPickerTextDelegate extends AssetPickerTextDelegate {
+  @override
+  String get languageCode => 'fr';
+
   @override
   String get confirm => 'OK';
 

--- a/lib/src/delegates/asset_picker_text_delegate.dart
+++ b/lib/src/delegates/asset_picker_text_delegate.dart
@@ -6,7 +6,7 @@ import 'package:photo_manager/photo_manager.dart' show AssetType;
 
 /// Text delegate that controls text in widgets.
 /// 控制部件中的文字实现
-class AssetsPickerTextDelegate {
+class AssetPickerTextDelegate {
   /// Confirm string for the confirm button.
   /// 确认按钮的字段
   String get confirm => '确认';
@@ -123,9 +123,9 @@ class AssetsPickerTextDelegate {
   String get sUnitAssetCountLabel => '数量';
 }
 
-/// [AssetsPickerTextDelegate] implements with English.
+/// [AssetPickerTextDelegate] implements with English.
 /// English Localization
-class EnglishTextDelegate extends AssetsPickerTextDelegate {
+class EnglishTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Confirm';
 
@@ -217,9 +217,9 @@ class EnglishTextDelegate extends AssetsPickerTextDelegate {
   String get sUnitAssetCountLabel => 'count';
 }
 
-/// [AssetsPickerTextDelegate] implements with Hebrew.
+/// [AssetPickerTextDelegate] implements with Hebrew.
 /// תרגום בשפה העברית
-class HebrewTextDelegate extends AssetsPickerTextDelegate {
+class HebrewTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'אישור';
 
@@ -277,9 +277,9 @@ class HebrewTextDelegate extends AssetsPickerTextDelegate {
   String get accessiblePathName => 'קבצים נגישים';
 }
 
-/// [AssetsPickerTextDelegate] implementiert mit der deutschen Übersetzung.
+/// [AssetPickerTextDelegate] implementiert mit der deutschen Übersetzung.
 /// Deutsche Textimplementierung.
-class GermanTextDelegate extends AssetsPickerTextDelegate {
+class GermanTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Bestätigen';
 
@@ -336,9 +336,9 @@ class GermanTextDelegate extends AssetsPickerTextDelegate {
   String get accessiblePathName => 'Verfügbare Assets';
 }
 
-/// [AssetsPickerTextDelegate] implements with Russian.
+/// [AssetPickerTextDelegate] implements with Russian.
 /// Локализация на русский язык.
-class RussianTextDelegate extends AssetsPickerTextDelegate {
+class RussianTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'Готово';
 
@@ -398,9 +398,9 @@ class RussianTextDelegate extends AssetsPickerTextDelegate {
   String get accessiblePathName => 'Доступные файлы';
 }
 
-/// [AssetsPickerTextDelegate] implements with Japanese.
+/// [AssetPickerTextDelegate] implements with Japanese.
 /// 日本語の TextDelegate
-class JapaneseTextDelegate extends AssetsPickerTextDelegate {
+class JapaneseTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => '決定';
 
@@ -459,9 +459,9 @@ class JapaneseTextDelegate extends AssetsPickerTextDelegate {
   String get accessiblePathName => 'アクセスできるリソース';
 }
 
-/// [AssetsPickerTextDelegate] implements with Arabic.
+/// [AssetPickerTextDelegate] implements with Arabic.
 /// الترجمة العربية
-class ArabicTextDelegate extends AssetsPickerTextDelegate {
+class ArabicTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'تاكيد';
 
@@ -521,9 +521,9 @@ class ArabicTextDelegate extends AssetsPickerTextDelegate {
   String get accessiblePathName => 'ملفات يمكن الوصول إليها';
 }
 
-/// [AssetsPickerTextDelegate] implements with French.
+/// [AssetPickerTextDelegate] implements with French.
 /// Délégué texte français
-class FrenchTextDelegate extends AssetsPickerTextDelegate {
+class FrenchTextDelegate extends AssetPickerTextDelegate {
   @override
   String get confirm => 'OK';
 

--- a/lib/src/delegates/asset_picker_text_delegate.dart
+++ b/lib/src/delegates/asset_picker_text_delegate.dart
@@ -23,10 +23,6 @@ class AssetPickerTextDelegate {
   /// GIF指示的字段
   String get gifIndicator => 'GIF';
 
-  /// HEIC failed string.
-  /// HEIC 类型资源加载失败的字段
-  String get heicNotSupported => '尚未支持HEIC类型资源';
-
   /// Load failed string for item.
   /// 资源加载失败时的字段
   String get loadFailed => '加载失败';
@@ -139,9 +135,6 @@ class EnglishTextDelegate extends AssetPickerTextDelegate {
   String get gifIndicator => 'GIF';
 
   @override
-  String get heicNotSupported => 'Unsupported HEIC asset type.';
-
-  @override
   String get loadFailed => 'Load failed';
 
   @override
@@ -233,9 +226,6 @@ class HebrewTextDelegate extends AssetPickerTextDelegate {
   String get gifIndicator => 'GIF';
 
   @override
-  String get heicNotSupported => 'קובץ HEIC לא נתמך.';
-
-  @override
   String get loadFailed => 'הטעינה נכשלה';
 
   @override
@@ -293,9 +283,6 @@ class GermanTextDelegate extends AssetPickerTextDelegate {
   String get gifIndicator => 'GIF';
 
   @override
-  String get heicNotSupported => 'HEIC Format ist nicht unterstützt.';
-
-  @override
   String get loadFailed => 'Ladevorgang ist fehlgeschlagen';
 
   @override
@@ -350,9 +337,6 @@ class RussianTextDelegate extends AssetPickerTextDelegate {
 
   @override
   String get gifIndicator => 'GIF';
-
-  @override
-  String get heicNotSupported => 'Формат HEIC не поддерживается.';
 
   @override
   String get loadFailed => 'Ошибка при загрузке';
@@ -414,9 +398,6 @@ class JapaneseTextDelegate extends AssetPickerTextDelegate {
   String get gifIndicator => 'GIF';
 
   @override
-  String get heicNotSupported => 'HEIC フォーマットはサポートしていません。';
-
-  @override
   String get loadFailed => '読み込みに失敗しました。';
 
   @override
@@ -473,9 +454,6 @@ class ArabicTextDelegate extends AssetPickerTextDelegate {
 
   @override
   String get gifIndicator => 'GIF';
-
-  @override
-  String get heicNotSupported => 'نوع HEIC غير مدعوم.';
 
   @override
   String get loadFailed => 'فشل التحميل';
@@ -535,9 +513,6 @@ class FrenchTextDelegate extends AssetPickerTextDelegate {
 
   @override
   String get gifIndicator => 'GIF';
-
-  @override
-  String get heicNotSupported => 'Type de fichier non supporté';
 
   @override
   String get loadFailed => 'Echec du chargement';

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -18,7 +18,7 @@ import '../constants/custom_scroll_physics.dart';
 import '../constants/enums.dart';
 import '../constants/extensions.dart';
 import '../delegates/asset_picker_builder_delegate.dart';
-import '../delegates/assets_picker_text_delegate.dart';
+import '../delegates/asset_picker_text_delegate.dart';
 import '../provider/asset_picker_provider.dart';
 import '../provider/asset_picker_viewer_provider.dart';
 import '../widget/asset_picker_viewer.dart';
@@ -153,7 +153,7 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
   /// 当前平台是否为苹果系列系统
   bool get isAppleOS => Platform.isIOS || Platform.isMacOS;
 
-  AssetsPickerTextDelegate get textDelegate => Constants.textDelegate;
+  AssetPickerTextDelegate get textDelegate => Constants.textDelegate;
 
   /// Call when viewer is calling [initState].
   /// 当预览器调用 [initState] 时注册 [State] 和 [TickerProvider]。

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -108,8 +108,6 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
           provider: provider,
           initialPermission: _ps,
           gridCount: gridCount,
-          textDelegate: textDelegate,
-          themeColor: themeColor,
           pickerTheme: pickerTheme,
           gridThumbSize: gridThumbSize,
           previewThumbSize: previewThumbSize,
@@ -120,6 +118,9 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
           allowSpecialItemWhenEmpty: allowSpecialItemWhenEmpty,
           selectPredicate: selectPredicate,
           shouldRevertGrid: shouldRevertGrid,
+          textDelegate: textDelegate,
+          themeColor: themeColor,
+          locale: Localizations.maybeLocaleOf(context),
         ),
       ),
     );

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -11,7 +11,7 @@ import 'package:provider/provider.dart';
 import '../constants/constants.dart';
 import '../constants/enums.dart';
 import '../delegates/asset_picker_builder_delegate.dart';
-import '../delegates/assets_picker_text_delegate.dart';
+import '../delegates/asset_picker_text_delegate.dart';
 import '../delegates/sort_path_delegate.dart';
 import '../provider/asset_picker_provider.dart';
 import 'asset_picker_page_route.dart';
@@ -45,7 +45,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
     Color? themeColor,
     ThemeData? pickerTheme,
     SortPathDelegate<AssetPathEntity>? sortPathDelegate,
-    AssetsPickerTextDelegate? textDelegate,
+    AssetPickerTextDelegate? textDelegate,
     FilterOptionGroup? filterOptions,
     WidgetBuilder? specialItemBuilder,
     IndicatorBuilder? loadingIndicatorBuilder,

--- a/lib/wechat_assets_picker.dart
+++ b/lib/wechat_assets_picker.dart
@@ -4,8 +4,8 @@ export 'package:photo_manager/photo_manager.dart';
 
 export 'src/constants/enums.dart';
 export 'src/delegates/asset_picker_builder_delegate.dart';
+export 'src/delegates/asset_picker_text_delegate.dart';
 export 'src/delegates/asset_picker_viewer_builder_delegate.dart';
-export 'src/delegates/assets_picker_text_delegate.dart';
 export 'src/delegates/sort_path_delegate.dart';
 export 'src/provider/asset_picker_provider.dart';
 export 'src/provider/asset_picker_viewer_provider.dart';


### PR DESCRIPTION
Text delegates can be obtained according to `Locale`.

Breaking changes:
- `AssetsPickerTextDelegate` -> `AssetPickerTextDelegate`
- ~`AssetPickerTextDelegate.heicNotSupported`~
- `*TextDelegate` -> `*AssetPickerTextDelagate`