### PR TITLE
♻️ Improve architecture for better customizations

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -19,7 +19,8 @@ Language: [English](README.md) | 中文
 需要拍照及录制视频，请查看示例的详细用法，
 并前往 [wechat_camera_picker](https://pub.flutter-io.cn/packages/wechat_camera_picker) 。
 
-所有的界面细节基于 **微信 8.x 版本**，将在微信版本更新后随时进行跟进。
+当前的界面设计基于的微信版本：**8.x**
+界面更新将在微信版本更新后随时进行跟进。
 
 **注意：** 如果你觉得你的自定义实现会在某些程度上帮助其他人实现他们的需求，你可以通过 PR 提交你的自定义实现。
 更多信息请参考 [贡献自定义实现](example/lib/customs/CONTRIBUTING.md) 。
@@ -60,7 +61,7 @@ Language: [English](README.md) | 中文
 - 💚 99% 的微信风格
 - ⚡️ 根据参数可调的性能优化
 - 📷 图片资源支持
-  - 🔬 HEIC/HEIF 格式图片支持
+  - 🔬 HEIF 格式图片支持
 - 🎥 视频资源支持
 - 🎶 音频资源支持
 - 1️⃣ 单资源模式
@@ -76,7 +77,7 @@ Language: [English](README.md) | 中文
 ## 截图 📸
 
 | ![1](https://pic.alexv525.com/2021-07-05-picker_1.jpg)   | ![2](https://pic.alexv525.com/2021-07-05-picker_2.jpg)   | ![3](https://pic.alexv525.com/2021-07-05-picker_3.jpg)   |
-| -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+|----------------------------------------------------------|----------------------------------------------------------|----------------------------------------------------------|
 | ![4](https://pic.alexv525.com/2021-07-05-picker_4.jpg)   | ![5](https://pic.alexv525.com/2021-07-05-picker_5.jpg)   | ![6](https://pic.alexv525.com/2021-07-05-picker_6.jpg)   |
 | ![7](https://pic.alexv525.com/2021-07-06-picker_7.jpg)   | ![8](https://pic.alexv525.com/2021-07-05-picker_8.jpg)   | ![9](https://pic.alexv525.com/2021-07-05-picker_9-1.jpg) |
 | ![10](https://pic.alexv525.com/2021-07-05-picker_10.png) | ![10](https://pic.alexv525.com/2021-07-05-picker_11.png) | ![12](https://pic.alexv525.com/2021-07-05-picker_12.png) |
@@ -97,8 +98,8 @@ Language: [English](README.md) | 中文
 | 6.2.0  |   ✅   |   ✅   |   ✅   |
 | 5.0.0+ |   ✅   |  N/A  |  N/A  |
 
-如果在 `flutter pub get` 时遇到了失败问题，请使用 `dependency_overrides` 解决。
-参考 [版本获取冲突](#xxx-版本获取冲突-例如-dartx)。
+如果在 `flutter pub get` 时遇到了 `resolve conflict` 失败问题，
+请使用 `dependency_overrides` 解决。
 
 ### Flutter
 
@@ -167,30 +168,30 @@ platform :ios, '9.0'
 
 ## 使用方法 📖
 
-| 参数名                     | 类型                    | 描述                                      | 默认值             |
-| ------------------------- | ---------------------- | ------------------------------------------------ | ------------------- |
-| selectedAssets            | `List<AssetEntity>?`   | 已选的资源。确保不重复选择。如果你允许重复选择，请将其置空。 | `null`              |
-| maxAssets                 | `int`                  | 最多选择的图片数量                      | 9                   |
-| pageSize                  | `int`                  | 分页加载时每页加载的资源数量。**必须为网格数的倍数。** 设置为`null`可以取消分页。 | 320 (80 * 4) |
-| gridThumbSize             | `int`                  | 预览网格的缩略图大小                     | 200                  |
-| pathThumbSize             | `int`                  | 路径选择器的缩略图大小                    | 80                  |
-| previewThumbSize          | `List<int>?`           | 预览时图片的缩略图大小                    | `null`                 |
-| gridCount                 | `int`                  | 选择器网格数量                        | 4                   |
-| requestType               | `RequestType`          | 选择器选择资源的类型                    | `RequestType.image` |
-| specialPickerType         | `SpecialPickerType?`   | 提供一些特殊的选择器类型以整合非常规的选择行为 | `null` |
-| themeColor                | `Color?`               | 选择器的主题色  | `Color(0xff00bc56)` |
-| pickerTheme               | `ThemeData?`           | 选择器的主题提供，包括查看器 | `null` |
-| sortPathDelegate          | `SortPathDeleage?`     | 资源路径的排序实现，可自定义路径排序方法 | `CommonSortPathDelegate` |
-| textDelegate              | `DefaultAssetsPickerTextDelegate?` | 选择器的文本代理构建，用于自定义文本 | `DefaultAssetsPickerTextDelegate()` |
-| filterOptions             | `FilterOptionGroup?`   | 允许用户自定义资源过滤条件 | `null` |
-| specialItemBuilder        | `WidgetBuilder?`       | 自定义item的构造方法 | `null` |
-| specialItemPosition       | `SpecialItemPosition`  | 允许用户在选择器中添加一个自定义item，并指定位置。 | `SpecialPosition.none` |
-| loadingIndicatorBuilder   | `IndicatorBuilder?`    | 加载器的实现                          | `null`                  |
-| allowSpecialItemWhenEmpty | `bool`                 | 在资源为空时是否允许显示自定义item  | `false` |
-| selectPredicate           | `AssetSelectPredicate` | 判断资源可否被选择 | `null`                              |
-| shouldRevertGrid          | `bool?`                | 判断资源网格是否需要倒序排列 | `null`                              |
-| routeCurve                | `Curve`                | 选择构造路由动画的曲线 | `Curves.easeIn` |
-| routeDuration             | `Duration`             | 选择构造路由动画的时间 | `const Duration(milliseconds: 500)` |
+| 参数名                       | 类型                                 | 描述                                             | 默认值                                 |
+|---------------------------|------------------------------------|------------------------------------------------|-------------------------------------|
+| selectedAssets            | `List<AssetEntity>?`               | 已选的资源。确保不重复选择。如果你允许重复选择，请将其置空。                 | `null`                              |
+| maxAssets                 | `int`                              | 最多选择的图片数量                                      | 9                                   |
+| pageSize                  | `int`                              | 分页加载时每页加载的资源数量。**必须为网格数的倍数。** 设置为`null`可以取消分页。 | 320 (80 * 4)                        |
+| gridThumbSize             | `int`                              | 预览网格的缩略图大小                                     | 200                                 |
+| pathThumbSize             | `int`                              | 路径选择器的缩略图大小                                    | 80                                  |
+| previewThumbSize          | `List<int>?`                       | 预览时图片的缩略图大小                                    | `null`                              |
+| gridCount                 | `int`                              | 选择器网格数量                                        | 4                                   |
+| requestType               | `RequestType`                      | 选择器选择资源的类型                                     | `RequestType.image`                 |
+| specialPickerType         | `SpecialPickerType?`               | 提供一些特殊的选择器类型以整合非常规的选择行为                        | `null`                              |
+| themeColor                | `Color?`                           | 选择器的主题色                                        | `Color(0xff00bc56)`                 |
+| pickerTheme               | `ThemeData?`                       | 选择器的主题提供，包括查看器                                 | `null`                              |
+| sortPathDelegate          | `SortPathDeleage?`                 | 资源路径的排序实现，可自定义路径排序方法                           | `CommonSortPathDelegate`            |
+| textDelegate              | `DefaultAssetsPickerTextDelegate?` | 选择器的文本代理构建，用于自定义文本                             | `DefaultAssetsPickerTextDelegate()` |
+| filterOptions             | `FilterOptionGroup?`               | 允许用户自定义资源过滤条件                                  | `null`                              |
+| specialItemBuilder        | `WidgetBuilder?`                   | 自定义item的构造方法                                   | `null`                              |
+| specialItemPosition       | `SpecialItemPosition`              | 允许用户在选择器中添加一个自定义item，并指定位置。                    | `SpecialPosition.none`              |
+| loadingIndicatorBuilder   | `IndicatorBuilder?`                | 加载器的实现                                         | `null`                              |
+| allowSpecialItemWhenEmpty | `bool`                             | 在资源为空时是否允许显示自定义item                            | `false`                             |
+| selectPredicate           | `AssetSelectPredicate`             | 判断资源可否被选择                                      | `null`                              |
+| shouldRevertGrid          | `bool?`                            | 判断资源网格是否需要倒序排列                                 | `null`                              |
+| routeCurve                | `Curve`                            | 选择构造路由动画的曲线                                    | `Curves.easeIn`                     |
+| routeDuration             | `Duration`                         | 选择构造路由动画的时间                                    | `const Duration(milliseconds: 500)` |
 
 ### 简单的使用方法
 
@@ -200,18 +201,11 @@ final List<AssetEntity> assets = await AssetPicker.pickAssets(context);
 
 ### 使用自定义代理
 
-```dart
-final YourAssetPickerProvider provider = yourProvider;
-final CustomAssetPickerBuilderDelegate builder = yourBuilder(provider);
-final List<YourAssetEntity>? result = await AssetPicker.pickAssetsWithDelegate(
-  context,
-  provider: provider,
-  delegate: builder,
-);
-```
-
 你只能在使用 `pickAssetsWithDelegate` 方法时使用 `keepScrollOffset` 的功能。
 更多细节请查看示例内的 `Keep scroll offset` 方法。
+
+想要了解更多关于自定义代理实现的内容，
+查阅 [`example/lib/customs`](example/lib/customs)。
 
 ### 更详细的使用方法
 
@@ -237,8 +231,9 @@ final List<YourAssetEntity>? result = await AssetPicker.pickAssetsWithDelegate(
 #### 自定义选择器
 
 你可以在「Custom」页面尝试自定义的选择器。
-目前我们只提供了一个基于 `Directory` 和 `File`
-（与 `photo_manager` 完全无关）实现的选择器。
+目前我们提供了一个基于 `Directory` 和 `File`
+（与 `photo_manager` 完全无关）实现的选择器，
+以及一个多 Tab 页切换的选择器。
 如果你觉得你的实现有价值或能帮助到其他人，欢迎以 PR 的形式进行提交。
 更多细节请阅读 [贡献自定义实现][example/lib/customs/CONTRIBUTING.md]
 
@@ -336,11 +331,21 @@ class CustomSortPathDelegate extends CommonSortPathDelegate {
 
 ```dart
 final File file = your_file; // 你的 File 对象
-final Uint8List byteData = await file.readAsBytes(); // 转为 Uint8List
-final AssetEntity imageEntity = await PhotoManager.editor.saveImage(byteData); // 存入手机并生成 AssetEntity
+final String path = file.path;
+final AssetEntity fileEntity = await PhotoManager.editor.saveImageWithPath(
+  path,
+  title: basename(path),
+); // 存入手机并生成 AssetEntity
+
+final Uint8List data = your_data; // 你的 Uint8List 对象
+final AssetEntity imageEntity = await PhotoManager.editor.saveImage(
+  file.path,
+  title: '带有后缀的名称.jpg',
+); // 存入手机并生成 AssetEntity
 ```
 
-如果不想保留文件，可以在操作完成（上传完或业务处理完）后进行删除：
+**注意：如果不想保留文件，请尽量用 `File` 承载中间操作，**
+否则在调用 `AssetEntity` 的删除时，某些系统下会触发系统弹窗事件：
 
 ```dart
 final List<String> result = await PhotoManager.editor.deleteWithIds([entity.id]);

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ and `provider` to help control the state of the picker.
 To take a photo or a video for assets, please check the detailed usage in the example, and head over to
 [wechat_camera_picker](https://pub.dev/packages/wechat_camera_picker).
 
-All UI designs are based on WeChat 8.x, and it will be updated following the WeChat update in anytime.
+Current WeChat version that UI based on: **8.x**
+UI designs will be updated following the WeChat update in anytime.
 
 ## Category 🗂
 
@@ -29,7 +30,7 @@ All UI designs are based on WeChat 8.x, and it will be updated following the WeC
 * [Features](#features-)
 * [Screenshots](#screenshots-)
 * [Preparing for use](#preparing-for-use-)
-  * [Versions compatibility](#version-compatibility)
+  * [Versions compatibility](#versions-compatibility)
   * [Flutter](#flutter)
   * [Android](#android)
   * [iOS](#ios)
@@ -58,7 +59,7 @@ See [Migration Guide](guides/migration_guide.md).
 - 💚 99% similar to WeChat style
 - ⚡️ Adjustable performance according to parameters
 - 📷 Image asset support
-  - 🔬 HEIC/HEIF Image type support
+  - 🔬 HEIF Image type support
 - 🎥 Video asset support
 - 🎶 Audio asset support
 - 1️⃣ Single asset mode
@@ -74,7 +75,7 @@ See [Migration Guide](guides/migration_guide.md).
 ## Screenshots 📸
 
 | ![1](https://pic.alexv525.com/2021-07-05-picker_1.jpg)   | ![2](https://pic.alexv525.com/2021-07-05-picker_2.jpg)   | ![3](https://pic.alexv525.com/2021-07-05-picker_3.jpg)   |
-| -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+|----------------------------------------------------------|----------------------------------------------------------|----------------------------------------------------------|
 | ![4](https://pic.alexv525.com/2021-07-05-picker_4.jpg)   | ![5](https://pic.alexv525.com/2021-07-05-picker_5.jpg)   | ![6](https://pic.alexv525.com/2021-07-05-picker_6.jpg)   |
 | ![7](https://pic.alexv525.com/2021-07-06-picker_7.jpg)   | ![8](https://pic.alexv525.com/2021-07-05-picker_8.jpg)   | ![9](https://pic.alexv525.com/2021-07-05-picker_9-1.jpg) |
 | ![10](https://pic.alexv525.com/2021-07-05-picker_10.png) | ![10](https://pic.alexv525.com/2021-07-05-picker_11.png) | ![12](https://pic.alexv525.com/2021-07-05-picker_12.png) |
@@ -97,7 +98,7 @@ please run the example or refer to [photo_manager](https://github.com/CaiJingLon
 | 5.0.0+ |   ✅   |  N/A  |  N/A  |  N/A  |
 
 If you got a `resolve conflict` error when running `flutter pub get`,
-please use `dependency_overrides` to fix it. See [here](#version-resolve-conflict-with-xxx-eg-dartx) .
+please use `dependency_overrides` to fix it.
 
 ### Flutter
 
@@ -161,30 +162,30 @@ platform :osx, '10.15'
 
 ## Usage 📖
 
-| Name                      | Type                        | Description                                                  | Default                             |
-| ------------------------- | --------------------------- | ------------------------------------------------------------ | ----------------------------------- |
+| Name                      | Type                        | Description                                                                                                         | Default                             |
+|---------------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | selectedAssets            | `List<AssetEntity>?`        | Selected assets. Prevent duplicate selection. If you don't need to prevent duplicate selection, just don't pass it. | `null`                              |
-| maxAssets                 | `int`                       | Maximum asset that the picker can pick.                      | 9                                   |
-| pageSize                  | `int?`                      | Number of assets per page. **Must be a multiple of `gridCount`**. | 320 (80 * 4)                        |
-| gridThumbSize             | `int`                       | Thumbnail size for the grid's item.                          | 200                                 |
-| pathThumbSize             | `int`                       | Thumbnail size for the path selector.                        | 80                                  |
-| previewThumbSize          | `List<int>?`                | Preview thumbnail size in the viewer.                        | `null`                              |
-| gridCount                 | `int`                       | Grid count in picker.                                        | 4                                   |
-| requestType               | `RequestType`               | Request type for picker.                                     | `RequestType.image`                 |
-| specialPickerType         | `SpacialPickerType?`        | Provides the option to integrate a custom picker type.       | `null`                              |
-| themeColor                | `Color?`                    | Main theme color for the picker.                             | `Color(0xff00bc56)`                 |
-| pickerTheme               | `ThemeData?`                | Theme data provider for the picker and the viewer.           | `null`                              |
-| sortPathDelegate          | `SortPathDeleage?`          | Path entities sort delegate for the picker, sort paths as you want. | `CommonSortPathDelegate`            |
-| textDelegate              | `AssetsPickerTextDelegate?` | Text delegate for the picker, for customize the texts.       | `DefaultAssetsPickerTextDelegate()` |
-| filterOptions             | `FilterOptionGroup?`        | Allow users to customize assets filter options.              | `null`                              |
-| specialItemBuilder        | `WidgetBuilder?`            | The widget builder for the special item.                     | `null`                              |
-| specialItemPosition       | `SpecialItemPosition`       | Allow users set a special item in the picker with several positions. | `SpecialItemPosition.none`          |
-| loadingIndicatorBuilder   | `IndicatorBuilder?`         | Indicates the loading status for the builder.                | `null`                              |
-| allowSpecialItemWhenEmpty | `bool`                      | Whether the special item will display or not when assets is empty. | `false`                             |
-| selectPredicate           | `AssetSelectPredicate`      | Predicate whether an asset can be selected or unselected.    | `null`                              |
-| shouldRevertGrid          | `bool?`                     | Whether the assets grid should revert.                       | `null`                              |
-| routeCurve                | `Curve`                     | The curve which the picker use to build page route transition. | `Curves.easeIn`                     |
-| routeDuration             | `Duration`                  | The duration which the picker use to build page route transition. | `const Duration(milliseconds: 500)` |
+| maxAssets                 | `int`                       | Maximum asset that the picker can pick.                                                                             | 9                                   |
+| pageSize                  | `int?`                      | Number of assets per page. **Must be a multiple of `gridCount`**.                                                   | 320 (80 * 4)                        |
+| gridThumbSize             | `int`                       | Thumbnail size for the grid's item.                                                                                 | 200                                 |
+| pathThumbSize             | `int`                       | Thumbnail size for the path selector.                                                                               | 80                                  |
+| previewThumbSize          | `List<int>?`                | Preview thumbnail size in the viewer.                                                                               | `null`                              |
+| gridCount                 | `int`                       | Grid count in picker.                                                                                               | 4                                   |
+| requestType               | `RequestType`               | Request type for picker.                                                                                            | `RequestType.image`                 |
+| specialPickerType         | `SpacialPickerType?`        | Provides the option to integrate a custom picker type.                                                              | `null`                              |
+| themeColor                | `Color?`                    | Main theme color for the picker.                                                                                    | `Color(0xff00bc56)`                 |
+| pickerTheme               | `ThemeData?`                | Theme data provider for the picker and the viewer.                                                                  | `null`                              |
+| sortPathDelegate          | `SortPathDeleage?`          | Path entities sort delegate for the picker, sort paths as you want.                                                 | `CommonSortPathDelegate`            |
+| textDelegate              | `AssetsPickerTextDelegate?` | Text delegate for the picker, for customize the texts.                                                              | `DefaultAssetsPickerTextDelegate()` |
+| filterOptions             | `FilterOptionGroup?`        | Allow users to customize assets filter options.                                                                     | `null`                              |
+| specialItemBuilder        | `WidgetBuilder?`            | The widget builder for the special item.                                                                            | `null`                              |
+| specialItemPosition       | `SpecialItemPosition`       | Allow users set a special item in the picker with several positions.                                                | `SpecialItemPosition.none`          |
+| loadingIndicatorBuilder   | `IndicatorBuilder?`         | Indicates the loading status for the builder.                                                                       | `null`                              |
+| allowSpecialItemWhenEmpty | `bool`                      | Whether the special item will display or not when assets is empty.                                                  | `false`                             |
+| selectPredicate           | `AssetSelectPredicate`      | Predicate whether an asset can be selected or unselected.                                                           | `null`                              |
+| shouldRevertGrid          | `bool?`                     | Whether the assets grid should revert.                                                                              | `null`                              |
+| routeCurve                | `Curve`                     | The curve which the picker use to build page route transition.                                                      | `Curves.easeIn`                     |
+| routeDuration             | `Duration`                  | The duration which the picker use to build page route transition.                                                   | `const Duration(milliseconds: 500)` |
 
 ### Simple usage
 
@@ -194,18 +195,11 @@ final List<AssetEntity> assets = await AssetPicker.pickAssets(context);
 
 ### Using custom delegate
 
-```dart
-final YourAssetPickerProvider provider = yourProvider;
-final CustomAssetPickerBuilderDelegate builder = yourBuilder(provider);
-final List<YourAssetEntity>? result = await AssetPicker.pickAssetsWithDelegate(
-  context,
-  provider: provider,
-  delegate: builder,
-);
-```
-
 You can use the `keepScrollOffset` feature only with the `pickAssetsWithDelegate` method.
 See the `Keep scroll offset` pick method in the example for how to implement it.
+
+For more details about custom delegates,
+head over to [`example/lib/customs`](example/lib/customs).
 
 ### Detailed usage
 
@@ -232,8 +226,9 @@ Only one and maximum to one asset can be picked at once.
 #### Custom pickers
 
 You can try custom pickers with the "Custom" page.
-We only defined a picker that integrates with `Directory` and `File`
-(completely out of the `photo_manager` scope).
+We've defined a picker that integrates with `Directory` and `File`
+(completely out of the `photo_manager` scope),
+and a picker with multiple tabs switching.
 You can submit PRs to create your own implementation
 if you found your implementation might be useful for others.
 See [Contribute custom implementations][lib/customs/CONTRIBUTING.md]
@@ -337,13 +332,23 @@ In order to combine this package with camera shooting or something related,
 there's a solution about how to create an `AssetEntity` with `File` or `Uint8List` object.
 
 ```dart
-final File file = your_file; // Your file object
-final Uint8List byteData = await file.readAsBytes(); // Convert to Uint8List
-final AssetEntity imageEntity = await PhotoManager.editor.saveImage(byteData); // Saved in the device then create an AssetEntity
+final File file = your_file; // Your `File` object
+final String path = file.path;
+final AssetEntity fileEntity = await PhotoManager.editor.saveImageWithPath(
+  path,
+  title: basename(path),
+); // Saved in the device then create an AssetEntity
+
+final Uint8List data = your_data; // Your `Uint8List` object
+final AssetEntity imageEntity = await PhotoManager.editor.saveImage(
+  file.path,
+  title: 'title_with_extension.jpg',
+); // Saved in the device then create an AssetEntity
 ```
 
-If you don't want to keep the asset in your device,
-just delete it after you complete with your process (upload, editing, etc).
+**Notice: If you don't want to keep the file in your device,
+use `File` for operations as much as possible.**
+A deletion operation might call system popups with some OS:
 
 ```dart
 final List<String> result = await PhotoManager.editor.deleteWithIds([entity.id]);

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,3 @@
 # WeChat Assets Picker example
 
-This is an example for the `wechat_assets_picker` package.
+This is the example for the `wechat_assets_picker` package.

--- a/example/lib/constants/custom_pick_method.dart
+++ b/example/lib/constants/custom_pick_method.dart
@@ -4,6 +4,7 @@
 ///
 import 'package:flutter/widgets.dart';
 
+@immutable
 class CustomPickMethod {
   const CustomPickMethod({
     required this.icon,

--- a/example/lib/constants/page_mixin.dart
+++ b/example/lib/constants/page_mixin.dart
@@ -13,6 +13,7 @@ import '../widgets/method_list_view.dart';
 import '../widgets/selected_assets_list_view.dart';
 import 'picker_method.dart';
 
+@optionalTypeArgs
 mixin ExamplePageMixin<T extends StatefulWidget> on State<T> {
   final ValueNotifier<bool> isDisplayingDetail = ValueNotifier<bool>(true);
 

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -255,7 +255,6 @@ class PickMethod {
   }
 
   factory PickMethod.keepScrollOffset({
-    required DefaultAssetPickerProvider Function() provider,
     required DefaultAssetPickerBuilderDelegate Function() delegate,
     required Function(PermissionState state) onPermission,
     GestureLongPressCallback? onLongPress,
@@ -274,7 +273,6 @@ class PickMethod {
         onPermission(_ps);
         return AssetPicker.pickAssetsWithDelegate(
           context,
-          provider: provider(),
           delegate: delegate(),
         );
       },

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -137,8 +137,9 @@ class PickMethod {
                   }
                   final AssetPicker<AssetEntity, AssetPathEntity> picker =
                       context.findAncestorWidgetOfExactType()!;
-                  final DefaultAssetPickerProvider p =
-                      picker.builder.provider as DefaultAssetPickerProvider;
+                  final DefaultAssetPickerBuilderDelegate builder =
+                      picker.builder as DefaultAssetPickerBuilderDelegate;
+                  final DefaultAssetPickerProvider p = builder.provider;
                   await p.currentPathEntity!.refreshPathProperties();
                   await p.switchPath(p.currentPathEntity!);
                   p.selectAsset(result);

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -140,8 +140,8 @@ class PickMethod {
                   final DefaultAssetPickerBuilderDelegate builder =
                       picker.builder as DefaultAssetPickerBuilderDelegate;
                   final DefaultAssetPickerProvider p = builder.provider;
-                  await p.currentPathEntity!.refreshPathProperties();
-                  await p.switchPath(p.currentPathEntity!);
+                  await p.currentPath!.refreshPathProperties();
+                  await p.switchPath(p.currentPath!);
                   p.selectAsset(result);
                 },
                 child: const Center(

--- a/example/lib/customs/CONTRIBUTING.md
+++ b/example/lib/customs/CONTRIBUTING.md
@@ -18,4 +18,4 @@ Please think twice before you confirmed it should be pushed as a new implementat
 4. Brought all your implementations into the file you've just created.
 5. Add a `CustomPickMethod` at the `custom_picker_page.dart` file in `pickMethods`
    in order to build an entrance to your picker.
-6. Submit your PR with proper explainations with how your picker works.
+6. Submit your PR with proper explanations with how your picker works.

--- a/example/lib/customs/custom_picker_page.dart
+++ b/example/lib/customs/custom_picker_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../constants/custom_pick_method.dart';
 import 'pickers/directory_file_asset_picker.dart';
+import 'pickers/multi_tabs_assets_picker.dart';
 
 class CustomPickersPage extends StatefulWidget {
   @override
@@ -37,6 +38,15 @@ class _CustomPickerPageState extends State<CustomPickersPage>
           MaterialPageRoute<void>(
             builder: (_) => const DirectoryFileAssetPicker(),
           ),
+        ),
+      ),
+      CustomPickMethod(
+        icon: '🔀',
+        name: 'Multi tab picker',
+        description: 'The picker contains multiple tab with different types of '
+            'assets for the picking at the same time.',
+        method: (BuildContext context) => Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(builder: (_) => const MultiTabAssetPicker()),
         ),
       ),
     ];

--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -37,8 +37,7 @@ class DirectoryFileAssetPicker extends StatefulWidget {
       _DirectoryFileAssetPickerState();
 }
 
-class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker>
-    with AutomaticKeepAliveClientMixin {
+class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker> {
   final List<File> fileList = <File>[];
 
   bool isDisplayingDetail = true;
@@ -56,7 +55,6 @@ class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker>
     final List<File>? result = await AssetPicker.pickAssetsWithDelegate(
       context,
       delegate: builder,
-      provider: provider,
     );
     if (result != null) {
       fileList
@@ -248,12 +246,7 @@ class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker>
   }
 
   @override
-  bool get wantKeepAlive => true;
-
-  @override
-  @mustCallSuper
   Widget build(BuildContext context) {
-    super.build(context);
     return Scaffold(
       appBar: AppBar(title: const Text('Directory+File picker')),
       body: Column(

--- a/example/lib/customs/pickers/multi_tabs_assets_picker.dart
+++ b/example/lib/customs/pickers/multi_tabs_assets_picker.dart
@@ -1,0 +1,532 @@
+///
+/// [Author] Alex (https://github.com/AlexV525)
+/// [Date] 2022/2/10 09:57
+///
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+const Color _themeColor = Color(0xfff2223a);
+
+class MultiTabAssetPicker extends StatefulWidget {
+  const MultiTabAssetPicker({Key? key}) : super(key: key);
+
+  @override
+  _MultiTabAssetPickerState createState() => _MultiTabAssetPickerState();
+}
+
+class _MultiTabAssetPickerState extends State<MultiTabAssetPicker> {
+  final int maxAssets = 9;
+  late final ThemeData theme = AssetPicker.themeData(_themeColor);
+
+  List<AssetEntity> entities = <AssetEntity>[];
+
+  bool isDisplayingDetail = true;
+
+  Future<void> callPicker(BuildContext context) async {
+    final PermissionState _ps = await AssetPicker.permissionCheck();
+
+    final DefaultAssetPickerProvider provider = DefaultAssetPickerProvider(
+      selectedAssets: entities,
+      maxAssets: maxAssets,
+    );
+    final DefaultAssetPickerProvider imagesProvider =
+        DefaultAssetPickerProvider(
+      selectedAssets: entities,
+      maxAssets: maxAssets,
+      requestType: RequestType.image,
+    );
+    final DefaultAssetPickerProvider videosProvider =
+        DefaultAssetPickerProvider(
+      selectedAssets: entities,
+      maxAssets: maxAssets,
+      requestType: RequestType.video,
+    );
+    final MultiTabAssetPickerBuilder builder = MultiTabAssetPickerBuilder(
+      provider: provider,
+      imagesProvider: imagesProvider,
+      videosProvider: videosProvider,
+      initialPermission: _ps,
+      pickerTheme: theme,
+      locale: Localizations.maybeLocaleOf(context),
+    );
+    final List<AssetEntity>? result = await AssetPicker.pickAssetsWithDelegate(
+      context,
+      delegate: builder,
+    );
+    if (result != null) {
+      entities = result;
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  Widget get selectedAssetsWidget {
+    return AnimatedContainer(
+      duration: kThemeChangeDuration,
+      curve: Curves.easeInOut,
+      height: entities.isNotEmpty
+          ? isDisplayingDetail
+              ? 120.0
+              : 80.0
+          : 40.0,
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 20.0,
+            child: GestureDetector(
+              onTap: () {
+                if (entities.isNotEmpty) {
+                  setState(() {
+                    isDisplayingDetail = !isDisplayingDetail;
+                  });
+                }
+              },
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Text('Selected Assets'),
+                  Container(
+                    margin: const EdgeInsets.symmetric(
+                      horizontal: 10.0,
+                    ),
+                    padding: const EdgeInsets.all(4.0),
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.grey,
+                    ),
+                    child: Text(
+                      '${entities.length}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        height: 1.0,
+                      ),
+                    ),
+                  ),
+                  if (entities.isNotEmpty)
+                    Icon(
+                      isDisplayingDetail
+                          ? Icons.arrow_downward
+                          : Icons.arrow_upward,
+                      size: 18.0,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          selectedAssetsListView,
+        ],
+      ),
+    );
+  }
+
+  Widget get selectedAssetsListView {
+    return Expanded(
+      child: ListView.builder(
+        physics: const BouncingScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        scrollDirection: Axis.horizontal,
+        itemCount: entities.length,
+        itemBuilder: (BuildContext _, int index) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 8.0,
+              vertical: 16.0,
+            ),
+            child: AspectRatio(
+              aspectRatio: 1.0,
+              child: Stack(
+                children: <Widget>[
+                  Positioned.fill(child: _selectedAssetWidget(index)),
+                  AnimatedPositionedDirectional(
+                    duration: kThemeAnimationDuration,
+                    top: isDisplayingDetail ? 6.0 : -30.0,
+                    end: isDisplayingDetail ? 6.0 : -30.0,
+                    child: _selectedAssetDeleteButton(index),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _selectedAssetWidget(int index) {
+    final AssetEntity asset = entities.elementAt(index);
+
+    Future<void> _onTap() async {
+      final List<AssetEntity>? result = await AssetPickerViewer.pushToViewer(
+        context,
+        currentIndex: index,
+        previewAssets: entities,
+        selectedAssets: entities,
+        themeData: theme,
+        maxAssets: maxAssets,
+      );
+      if (result != null) {
+        entities = result;
+        if (mounted) {
+          setState(() {});
+        }
+      }
+    }
+
+    return GestureDetector(
+      onTap: isDisplayingDetail ? _onTap : null,
+      child: RepaintBoundary(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8.0),
+          child: _assetWidgetBuilder(asset),
+        ),
+      ),
+    );
+  }
+
+  Widget _assetWidgetBuilder(AssetEntity asset) {
+    return Image(image: AssetEntityImageProvider(asset), fit: BoxFit.cover);
+  }
+
+  Widget _selectedAssetDeleteButton(int index) {
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          entities.removeAt(index);
+          if (entities.isEmpty) {
+            isDisplayingDetail = false;
+          }
+        });
+      },
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(4.0),
+          color: theme.canvasColor.withOpacity(0.5),
+        ),
+        child: Icon(
+          Icons.close,
+          color: theme.iconTheme.color,
+          size: 18.0,
+        ),
+      ),
+    );
+  }
+
+  Widget paddingText(String text) {
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: SelectableText(text),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Multi tab picker')),
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(fontSize: 18),
+              textAlign: TextAlign.center,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  paddingText(
+                    'The picker contains multiple tab with different types of '
+                    'assets for the picking at the same time.',
+                  ),
+                  TextButton(
+                    onPressed: () => callPicker(context),
+                    child: const Text(
+                      '🎁 Call the Picker',
+                      style: TextStyle(fontSize: 22),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          selectedAssetsWidget,
+        ],
+      ),
+    );
+  }
+}
+
+class MultiTabAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
+  MultiTabAssetPickerBuilder({
+    required DefaultAssetPickerProvider provider,
+    required this.videosProvider,
+    required this.imagesProvider,
+    required PermissionState initialPermission,
+    int gridCount = 3,
+    ThemeData? pickerTheme,
+    Color? themeColor,
+    AssetPickerTextDelegate? textDelegate,
+    Locale? locale,
+  }) : super(
+          provider: provider,
+          initialPermission: initialPermission,
+          gridCount: gridCount,
+          pickerTheme: pickerTheme,
+          themeColor: themeColor,
+          textDelegate: textDelegate,
+          locale: locale,
+          shouldRevertGrid: false,
+        );
+
+  final DefaultAssetPickerProvider videosProvider;
+  final DefaultAssetPickerProvider imagesProvider;
+
+  late final TabController _tabController;
+
+  @override
+  void initState(AssetPickerState<AssetEntity, AssetPathEntity> state) {
+    super.initState(state);
+    _tabController = TabController(length: 3, vsync: state);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget pathEntitySelector(BuildContext context) {
+    final WidgetBuilder selector = (BuildContext context) {
+      return UnconstrainedBox(
+        child: GestureDetector(
+          onTap: () {
+            Feedback.forTap(context);
+            isSwitchingPath.value = !isSwitchingPath.value;
+          },
+          child: Container(
+            height: appBarItemHeight,
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.5,
+            ),
+            padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(999),
+              color: theme.dividerColor,
+            ),
+            child: Selector<DefaultAssetPickerProvider, AssetPathEntity?>(
+              selector: (_, DefaultAssetPickerProvider p) => p.currentPath,
+              builder: (_, AssetPathEntity? p, Widget? w) => Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  if (p != null)
+                    Flexible(
+                      child: Text(
+                        isPermissionLimited && p.isAll
+                            ? textDelegate.accessiblePathName
+                            : p.name,
+                        style: const TextStyle(
+                          fontSize: 17,
+                          fontWeight: FontWeight.normal,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  w!,
+                ],
+              ),
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(start: 5),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: theme.iconTheme.color!.withOpacity(0.5),
+                  ),
+                  child: ValueListenableBuilder<bool>(
+                    valueListenable: isSwitchingPath,
+                    builder: (_, bool isSwitchingPath, Widget? w) {
+                      return Transform.rotate(
+                        angle: isSwitchingPath ? math.pi : 0,
+                        alignment: Alignment.center,
+                        child: w,
+                      );
+                    },
+                    child: Icon(
+                      Icons.keyboard_arrow_down,
+                      size: 20,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    };
+    return ChangeNotifierProvider<TabController>.value(
+      value: _tabController,
+      builder: (_, __) => Selector<TabController, int>(
+        selector: (_, TabController p) => p.index,
+        builder: (_, int index, __) {
+          final DefaultAssetPickerProvider _provider;
+          switch (index) {
+            case 1:
+              _provider = videosProvider;
+              break;
+            case 2:
+              _provider = imagesProvider;
+              break;
+            default:
+              _provider = provider;
+          }
+          return ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+            value: _provider,
+            builder: (BuildContext c, _) => selector(c),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget confirmButton(BuildContext context) {
+    final Widget button = Consumer<DefaultAssetPickerProvider>(
+      builder: (_, DefaultAssetPickerProvider p, __) {
+        return MaterialButton(
+          minWidth: p.isSelectedNotEmpty ? 48 : 20,
+          height: appBarItemHeight,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          disabledColor: theme.dividerColor,
+          color: p.isSelectedNotEmpty ? themeColor : theme.dividerColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(3),
+          ),
+          child: Text(
+            p.isSelectedNotEmpty && !isSingleAssetMode
+                ? '${textDelegate.confirm}'
+                    ' (${p.selectedAssets.length}/${p.maxAssets})'
+                : textDelegate.confirm,
+            style: TextStyle(
+              color: p.isSelectedNotEmpty
+                  ? theme.textTheme.bodyText1?.color
+                  : theme.textTheme.caption?.color,
+              fontSize: 17,
+              fontWeight: FontWeight.normal,
+            ),
+          ),
+          onPressed: p.isSelectedNotEmpty
+              ? () => Navigator.of(context).maybePop(p.selectedAssets)
+              : null,
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        );
+      },
+    );
+    return ChangeNotifierProvider<TabController>.value(
+      value: _tabController,
+      builder: (_, __) => Selector<TabController, int>(
+        selector: (_, TabController p) => p.index,
+        builder: (_, int index, __) {
+          final DefaultAssetPickerProvider _provider;
+          switch (index) {
+            case 1:
+              _provider = videosProvider;
+              break;
+            case 2:
+              _provider = imagesProvider;
+              break;
+            default:
+              _provider = provider;
+          }
+          return ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+            value: _provider,
+            builder: (_, __) => button,
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  AssetPickerAppBar appBar(BuildContext context) {
+    return AssetPickerAppBar(
+      backgroundColor: theme.appBarTheme.backgroundColor,
+      centerTitle: isAppleOS,
+      title: Semantics(
+        onTapHint: textDelegate.sActionSwitchPathLabel,
+        child: pathEntitySelector(context),
+      ),
+      leading: backButton(context),
+      actions: (isPreviewEnabled || !isSingleAssetMode)
+          ? <Widget>[confirmButton(context)]
+          : null,
+      actionsPadding: const EdgeInsetsDirectional.only(end: 14),
+      blurRadius: isAppleOS ? appleOSBlurRadius : 0,
+      bottom: TabBar(
+        controller: _tabController,
+        tabs: const <Tab>[
+          Tab(text: '全部'),
+          Tab(text: '视频'),
+          Tab(text: '图片'),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget androidLayout(BuildContext context) {
+    return AssetPickerAppBarWrapper(
+      appBar: appBar(context),
+      body: TabBarView(
+        controller: _tabController,
+        children: <Widget>[
+          ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+            value: provider,
+            builder: (BuildContext context, _) => _buildGrid(context),
+          ),
+          ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+            value: videosProvider,
+            builder: (BuildContext context, _) => _buildGrid(context),
+          ),
+          ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+            value: imagesProvider,
+            builder: (BuildContext context, _) => _buildGrid(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget appleOSLayout(BuildContext context) => androidLayout(context);
+
+  Widget _buildGrid(BuildContext context) {
+    return Selector<DefaultAssetPickerProvider, bool>(
+      selector: (_, DefaultAssetPickerProvider p) => p.hasAssetsToDisplay,
+      builder: (_, bool hasAssetsToDisplay, __) {
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: hasAssetsToDisplay
+              ? Stack(
+                  children: <Widget>[
+                    RepaintBoundary(
+                      child: Column(
+                        children: <Widget>[
+                          Expanded(child: assetsGridBuilder(context)),
+                          if (!isSingleAssetMode && isPreviewEnabled)
+                            bottomActionBar(context),
+                        ],
+                      ),
+                    ),
+                    pathEntityListBackdrop(context),
+                    pathEntityListWidget(context),
+                  ],
+                )
+              : loadingIndicator(context),
+        );
+      },
+    );
+  }
+}

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -52,7 +52,6 @@ class _MultiAssetsPageState extends State<MultiAssetsPage>
       PickMethod.customFilterOptions(maxAssetsCount),
       PickMethod.preventGIFPicked(maxAssetsCount),
       PickMethod.keepScrollOffset(
-        provider: () => keepScrollProvider,
         delegate: () => keepScrollDelegate!,
         onPermission: (PermissionState state) {
           keepScrollDelegate ??= DefaultAssetPickerBuilderDelegate(

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -14,7 +14,7 @@ class MultiAssetsPage extends StatefulWidget {
 }
 
 class _MultiAssetsPageState extends State<MultiAssetsPage>
-    with AutomaticKeepAliveClientMixin, ExamplePageMixin<MultiAssetsPage> {
+    with AutomaticKeepAliveClientMixin, ExamplePageMixin {
   @override
   int get maxAssetsCount => 9;
 

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -15,7 +15,7 @@ class SingleAssetPage extends StatefulWidget {
 }
 
 class _SingleAssetPageState extends State<SingleAssetPage>
-    with AutomaticKeepAliveClientMixin, ExamplePageMixin<SingleAssetPage> {
+    with AutomaticKeepAliveClientMixin, ExamplePageMixin {
   @override
   int get maxAssetsCount => 1;
 

--- a/example/lib/widgets/method_list_view.dart
+++ b/example/lib/widgets/method_list_view.dart
@@ -14,7 +14,7 @@ class MethodListView extends StatefulWidget {
   }) : super(key: key);
 
   final List<PickMethod> pickMethods;
-  final Function(PickMethod method) onSelectMethod;
+  final void Function(PickMethod method) onSelectMethod;
 
   @override
   _MethodListViewState createState() => _MethodListViewState();

--- a/example/lib/widgets/selected_assets_list_view.dart
+++ b/example/lib/widgets/selected_assets_list_view.dart
@@ -20,8 +20,8 @@ class SelectedAssetsListView extends StatelessWidget {
 
   final List<AssetEntity> assets;
   final ValueNotifier<bool> isDisplayingDetail;
-  final Function(List<AssetEntity>? result) onResult;
-  final Function(int index) onRemoveAsset;
+  final void Function(List<AssetEntity>? result) onResult;
+  final void Function(int index) onRemoveAsset;
 
   Widget _selectedAssetWidget(BuildContext context, int index) {
     final AssetEntity asset = assets.elementAt(index);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   wechat_camera_picker: ^3.0.0-dev.3
 
   extended_image: ^6.0.1
+  meta: ^1.7.0
   package_info_plus: ^1.3.0
   path: ^1.8.0
   path_provider: ^2.0.8

--- a/lib/src/constants/colors.dart
+++ b/lib/src/constants/colors.dart
@@ -1,9 +1,0 @@
-///
-/// [Author] Alex (https://github.com/Alex525)
-/// [Date] 2020/3/31 16:02
-///
-import 'package:flutter/painting.dart';
-
-class C {
-  static const Color themeColor = Color(0xff00bc56); // WeChat
-}

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -2,35 +2,9 @@
 /// [Author] Alex (https://github.com/Alex525)
 /// [Date] 2020/3/31 16:02
 ///
-import 'dart:developer';
+import 'package:flutter/painting.dart';
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+/// Default theme color from WeChat.
+const Color defaultThemeColorWeChat = Color(0xff00bc56);
 
-import '../delegates/asset_picker_text_delegate.dart';
-import '../delegates/sort_path_delegate.dart';
-
-class Constants {
-  const Constants._();
-
-  static GlobalKey pickerKey = GlobalKey();
-
-  static AssetPickerTextDelegate textDelegate = AssetPickerTextDelegate();
-  static SortPathDelegate<dynamic> sortPathDelegate = SortPathDelegate.common;
-
-  /// The last scroll position where the picker scrolled.
-  ///
-  /// See also:
-  ///  * [AssetPickerBuilderDelegate.keepScrollOffset]
-  static ScrollPosition? scrollPosition;
-
-  static const int defaultGridThumbSize = 200;
-}
-
-/// Log only in debug mode.
-/// 只在调试模式打印
-void realDebugPrint(dynamic message) {
-  if (!kReleaseMode) {
-    log('$message');
-  }
-}
+const int defaultAssetGridPreviewSize = 200;

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -41,5 +41,5 @@ enum SpecialItemPosition {
 
   /// Add as trailing of the list.
   /// 在列表后放入
-  append
+  append,
 }

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1250,66 +1250,57 @@ class DefaultAssetPickerBuilderDelegate
     AssetEntity asset,
     Widget child,
   ) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: isSwitchingPath,
-      builder: (_, bool isSwitchingPath, __) {
-        return Consumer<DefaultAssetPickerProvider>(
-          child: child,
-          builder: (_, DefaultAssetPickerProvider p, Widget? child) {
-            final bool isBanned = (!p.selectedAssets.contains(asset) &&
-                    p.selectedMaximumAssets) ||
+    return Consumer<DefaultAssetPickerProvider>(
+      child: child,
+      builder: (_, DefaultAssetPickerProvider p, Widget? child) {
+        final bool isBanned =
+            (!p.selectedAssets.contains(asset) && p.selectedMaximumAssets) ||
                 (isWeChatMoment &&
                     asset.type == AssetType.video &&
                     p.selectedAssets.isNotEmpty);
-            final bool isSelected = p.selectedDescriptions.contains(
-              asset.toString(),
-            );
-            final int selectedIndex = p.selectedAssets.indexOf(asset) + 1;
-            String hint = '';
-            if (asset.type == AssetType.audio ||
-                asset.type == AssetType.video) {
-              hint += '${textDelegate.sNameDurationLabel}: ';
-              hint +=
-                  textDelegate.durationIndicatorBuilder(asset.videoDuration);
-            }
-            if (asset.title?.isNotEmpty == true) {
-              hint += ', ${asset.title}';
-            }
-            return Semantics(
-              button: false,
-              enabled: !isBanned,
-              excludeSemantics: true,
-              focusable: isSwitchingPath,
-              label: '${textDelegate.semanticTypeLabel(asset.type)}'
-                  '${semanticIndex(index)}, '
-                  '${asset.createDateTime.toString().replaceAll('.000', '')}',
-              hidden: isSwitchingPath,
-              hint: hint,
-              image: asset.type == AssetType.image ||
-                  asset.type == AssetType.video,
-              onTap: () => selectAsset(context, asset, isSelected),
-              onTapHint: textDelegate.sActionSelectHint,
-              onLongPress: isPreviewEnabled
-                  ? () => _pushAssetToViewer(context, index, asset)
-                  : null,
-              onLongPressHint: textDelegate.sActionPreviewHint,
-              selected: isSelected,
-              sortKey: OrdinalSortKey(
-                semanticIndex(index).toDouble(),
-                name: 'GridItem',
-              ),
-              value: selectedIndex > 0 ? '$selectedIndex' : null,
-              child: GestureDetector(
-                // Regression https://github.com/flutter/flutter/issues/35112.
-                onLongPress:
-                    isPreviewEnabled && context.mediaQuery.accessibleNavigation
-                        ? () => _pushAssetToViewer(context, index, asset)
-                        : null,
-                child:
-                    IndexedSemantics(index: semanticIndex(index), child: child),
-              ),
-            );
-          },
+        final bool isSelected = p.selectedDescriptions.contains(
+          asset.toString(),
+        );
+        final int selectedIndex = p.selectedAssets.indexOf(asset) + 1;
+        String hint = '';
+        if (asset.type == AssetType.audio || asset.type == AssetType.video) {
+          hint += '${textDelegate.sNameDurationLabel}: ';
+          hint += textDelegate.durationIndicatorBuilder(asset.videoDuration);
+        }
+        if (asset.title?.isNotEmpty == true) {
+          hint += ', ${asset.title}';
+        }
+        return Semantics(
+          button: false,
+          enabled: !isBanned,
+          excludeSemantics: true,
+          focusable: !isSwitchingPath.value,
+          label: '${textDelegate.semanticTypeLabel(asset.type)}'
+              '${semanticIndex(index)}, '
+              '${asset.createDateTime.toString().replaceAll('.000', '')}',
+          hidden: isSwitchingPath.value,
+          hint: hint,
+          image: asset.type == AssetType.image || asset.type == AssetType.video,
+          onTap: () => selectAsset(context, asset, isSelected),
+          onTapHint: textDelegate.sActionSelectHint,
+          onLongPress: isPreviewEnabled
+              ? () => _pushAssetToViewer(context, index, asset)
+              : null,
+          onLongPressHint: textDelegate.sActionPreviewHint,
+          selected: isSelected,
+          sortKey: OrdinalSortKey(
+            semanticIndex(index).toDouble(),
+            name: 'GridItem',
+          ),
+          value: selectedIndex > 0 ? '$selectedIndex' : null,
+          child: GestureDetector(
+            // Regression https://github.com/flutter/flutter/issues/35112.
+            onLongPress:
+                isPreviewEnabled && context.mediaQuery.accessibleNavigation
+                    ? () => _pushAssetToViewer(context, index, asset)
+                    : null,
+            child: IndexedSemantics(index: semanticIndex(index), child: child),
+          ),
         );
       },
     );

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -910,7 +910,7 @@ class DefaultAssetPickerBuilderDelegate
   }
 
   @override
-  PreferredSizeWidget appBar(BuildContext context) {
+  AssetPickerAppBar appBar(BuildContext context) {
     return AssetPickerAppBar(
       backgroundColor: theme.appBarTheme.backgroundColor,
       centerTitle: isAppleOS,

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -206,17 +206,9 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
 
   AssetPickerTextDelegate get textDelegate => Constants.textDelegate;
 
-  /// The method to select assets. Delegates can implement this method
-  /// to involve with predications, callbacks, etc.
-  /// 选择资源的方法。自定义的 delegate 可以通过实现该方法，整合判断、回调等操作。
-  void selectAsset(BuildContext context, Asset asset, bool selected);
-
-  /// Called when assets changed and obtained notifications from the OS.
-  /// 系统发出资源变更的通知时调用的方法
-  Future<void> onAssetsChanged(MethodCall call, StateSetter setState) async {}
-
   /// Keep a dispose method to sync with [State].
   /// 保留一个 dispose 方法与 [State] 同步。
+  @mustCallSuper
   void dispose() {
     Constants.scrollPosition = null;
     gridScrollController.dispose();
@@ -224,6 +216,20 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     permission.dispose();
     permissionOverlayHidden.dispose();
   }
+
+  /// The method to select assets. Delegates can implement this method
+  /// to involve with predications, callbacks, etc.
+  /// 选择资源的方法。自定义的 delegate 可以通过实现该方法，整合判断、回调等操作。
+  @protected
+  void selectAsset(BuildContext context, Asset asset, bool selected);
+
+  /// Called when assets changed and obtained notifications from the OS.
+  /// 系统发出资源变更的通知时调用的方法
+  Future<void> onAssetsChanged(MethodCall call, StateSetter setState) async {}
+
+  /// Yes, the build method.
+  /// 没错，是它是它就是它，我们亲爱的 build 方法~
+  Widget build(BuildContext context);
 
   /// Path entity select widget builder.
   /// 路径选择部件构建
@@ -294,26 +300,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     );
   }
 
-  /// Audio asset type indicator.
-  /// 音频类型资源指示
-  Widget audioIndicator(BuildContext context, Asset asset);
-
-  /// Video asset type indicator.
-  /// 视频类型资源指示
-  Widget videoIndicator(BuildContext context, Asset asset);
-
-  /// Animated backdrop widget for items.
-  /// 部件选中时的动画遮罩部件
-  Widget selectedBackdrop(
-    BuildContext context,
-    int index,
-    Asset asset,
-  );
-
-  /// Indicator for assets selected status.
-  /// 资源是否已选的指示器
-  Widget selectIndicator(BuildContext context, int index, Asset asset);
-
   /// Indicator when the asset cannot be selected.
   /// 当资源无法被选中时的遮罩
   Widget itemBannedIndicator(BuildContext context, Asset asset) {
@@ -383,64 +369,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
     }
     return _od;
   }
-
-  /// The main grid view builder for assets.
-  /// 主要的资源查看网格部件
-  Widget assetsGridBuilder(BuildContext context);
-
-  /// Indicates how would the grid found a reusable [RenderObject] through [id].
-  /// 为 Grid 布局指示如何找到可复用的 [RenderObject]。
-  int? findChildIndexBuilder({
-    required String id,
-    required List<Asset> assets,
-    int placeholderCount = 0,
-  }) =>
-      null;
-
-  /// The function which return items count for the assets' grid.
-  /// 为资源列表提供内容数量计算的方法
-  int assetsGridItemCount({
-    required BuildContext context,
-    required List<Asset> assets,
-    int placeholderCount = 0,
-  });
-
-  /// The item builder for the assets' grid.
-  /// 资源列表项的构建
-  Widget assetGridItemBuilder(
-    BuildContext context,
-    int index,
-    List<Asset> currentAssets,
-  );
-
-  /// The [Semantics] builder for the assets' grid.
-  /// 资源列表项的语义构建
-  Widget assetGridItemSemanticsBuilder(
-    BuildContext context,
-    int index,
-    Asset asset,
-    Widget child,
-  );
-
-  /// The item builder for audio type of asset.
-  /// 音频资源的部件构建
-  Widget audioItemBuilder(
-    BuildContext context,
-    int index,
-    Asset asset,
-  );
-
-  /// The item builder for images and video type of asset.
-  /// 图片和视频资源的部件构建
-  Widget imageAndVideoItemBuilder(
-    BuildContext context,
-    int index,
-    Asset asset,
-  );
-
-  /// Preview button to preview selected assets.
-  /// 预览已选资源的按钮
-  Widget previewButton(BuildContext context);
 
   /// The tip widget displays when the access is limited.
   /// 当访问受限时在底部展示的提示
@@ -527,18 +455,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       ),
     );
   }
-
-  /// Custom app bar for the picker.
-  /// 选择器自定义的顶栏
-  PreferredSizeWidget appBar(BuildContext context);
-
-  /// Layout for Apple OS devices.
-  /// 苹果系列设备的选择器布局
-  Widget appleOSLayout(BuildContext context);
-
-  /// Layout for Android devices.
-  /// Android设备的选择器布局
-  Widget androidLayout(BuildContext context);
 
   /// The overlay when the permission is limited on iOS.
   Widget iOSPermissionOverlay(BuildContext context) {
@@ -628,10 +544,6 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       },
     );
   }
-
-  /// Yes, the build method.
-  /// 没错，是它是它就是它，我们亲爱的 build 方法~
-  Widget build(BuildContext context);
 }
 
 class DefaultAssetPickerBuilderDelegate

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -261,6 +261,99 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   /// 确认按钮
   Widget confirmButton(BuildContext context);
 
+  /// Audio asset type indicator.
+  /// 音频类型资源指示
+  Widget audioIndicator(BuildContext context, Asset asset);
+
+  /// Video asset type indicator.
+  /// 视频类型资源指示
+  Widget videoIndicator(BuildContext context, Asset asset);
+
+  /// Animated backdrop widget for items.
+  /// 部件选中时的动画遮罩部件
+  Widget selectedBackdrop(
+    BuildContext context,
+    int index,
+    Asset asset,
+  );
+
+  /// Indicator for assets selected status.
+  /// 资源是否已选的指示器
+  Widget selectIndicator(BuildContext context, int index, Asset asset);
+
+  /// The main grid view builder for assets.
+  /// 主要的资源查看网格部件
+  Widget assetsGridBuilder(BuildContext context);
+
+  /// Indicates how would the grid found a reusable [RenderObject] through [id].
+  /// 为 Grid 布局指示如何找到可复用的 [RenderObject]。
+  ///
+  /// See also:
+  ///  * [SliverChildBuilderDelegate.findChildIndexCallback].
+  int? findChildIndexBuilder({
+    required String id,
+    required List<Asset> assets,
+    int placeholderCount = 0,
+  }) =>
+      null;
+
+  /// The function which return items count for the assets' grid.
+  /// 为资源列表提供内容数量计算的方法
+  int assetsGridItemCount({
+    required BuildContext context,
+    required List<Asset> assets,
+    int placeholderCount = 0,
+  });
+
+  /// The item builder for the assets' grid.
+  /// 资源列表项的构建
+  Widget assetGridItemBuilder(
+    BuildContext context,
+    int index,
+    List<Asset> currentAssets,
+  );
+
+  /// The [Semantics] builder for the assets' grid.
+  /// 资源列表项的语义构建
+  Widget assetGridItemSemanticsBuilder(
+    BuildContext context,
+    int index,
+    Asset asset,
+    Widget child,
+  );
+
+  /// The item builder for audio type of asset.
+  /// 音频资源的部件构建
+  Widget audioItemBuilder(
+    BuildContext context,
+    int index,
+    Asset asset,
+  );
+
+  /// The item builder for images and video type of asset.
+  /// 图片和视频资源的部件构建
+  Widget imageAndVideoItemBuilder(
+    BuildContext context,
+    int index,
+    Asset asset,
+  );
+
+  /// Preview button to preview selected assets.
+  /// 预览已选资源的按钮
+  Widget previewButton(BuildContext context);
+
+  /// Custom app bar for the picker.
+  /// 选择器自定义的顶栏
+  PreferredSizeWidget appBar(BuildContext context);
+
+  /// Layout for Apple OS devices.
+  /// 苹果系列设备的选择器布局
+  Widget appleOSLayout(BuildContext context);
+
+  /// Layout for Android devices.
+  /// Android设备的选择器布局
+  Widget androidLayout(BuildContext context);
+
   /// GIF image type indicator.
   /// GIF 类型图片指示
   Widget gifIndicator(BuildContext context, Asset asset) {
@@ -709,8 +802,8 @@ class DefaultAssetPickerBuilderDelegate
     if (!isPermissionLimited) {
       return;
     }
-    if (provider.currentPathEntity != null) {
-      final AssetPathEntity? _currentPathEntity = provider.currentPathEntity;
+    if (provider.currentPath != null) {
+      final AssetPathEntity? _currentPathEntity = provider.currentPath;
       await _currentPathEntity?.refreshPathProperties();
       await provider.switchPath(_currentPathEntity);
       isSwitchingPath.value = false;
@@ -913,7 +1006,7 @@ class DefaultAssetPickerBuilderDelegate
   @override
   Widget assetsGridBuilder(BuildContext context) {
     return Selector<DefaultAssetPickerProvider, AssetPathEntity?>(
-      selector: (_, DefaultAssetPickerProvider p) => p.currentPathEntity,
+      selector: (_, DefaultAssetPickerProvider p) => p.currentPath,
       builder: (_, AssetPathEntity? path, __) {
         // First, we need the count of the assets.
         int totalCount = path?.assetCount ?? 0;
@@ -1077,7 +1170,7 @@ class DefaultAssetPickerBuilderDelegate
   ) {
     final AssetPathEntity? currentPathEntity =
         context.select<DefaultAssetPickerProvider, AssetPathEntity?>(
-      (DefaultAssetPickerProvider p) => p.currentPathEntity,
+      (DefaultAssetPickerProvider p) => p.currentPath,
     );
 
     int currentIndex;
@@ -1240,7 +1333,7 @@ class DefaultAssetPickerBuilderDelegate
   }) {
     final AssetPathEntity? currentPathEntity =
         context.select<DefaultAssetPickerProvider, AssetPathEntity?>(
-      (DefaultAssetPickerProvider p) => p.currentPathEntity,
+      (DefaultAssetPickerProvider p) => p.currentPath,
     );
 
     if (currentPathEntity == null &&
@@ -1524,12 +1617,11 @@ class DefaultAssetPickerBuilderDelegate
             Flexible(
               child: Selector<DefaultAssetPickerProvider, int>(
                 selector: (_, DefaultAssetPickerProvider p) =>
-                    p.validPathThumbCount,
+                    p.validPathThumbnailsCount,
                 builder: (_, int count, __) => Selector<
                     DefaultAssetPickerProvider,
                     Map<AssetPathEntity, Uint8List?>>(
-                  selector: (_, DefaultAssetPickerProvider p) =>
-                      p.pathEntityList,
+                  selector: (_, DefaultAssetPickerProvider p) => p.pathsList,
                   builder: (_, Map<AssetPathEntity, Uint8List?> list, __) {
                     return ListView.separated(
                       padding: const EdgeInsetsDirectional.only(top: 1),
@@ -1576,7 +1668,7 @@ class DefaultAssetPickerBuilderDelegate
             color: theme.dividerColor,
           ),
           child: Selector<DefaultAssetPickerProvider, AssetPathEntity?>(
-            selector: (_, DefaultAssetPickerProvider p) => p.currentPathEntity,
+            selector: (_, DefaultAssetPickerProvider p) => p.currentPath,
             builder: (_, AssetPathEntity? p, Widget? w) => Row(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
@@ -1663,7 +1755,7 @@ class DefaultAssetPickerBuilderDelegate
         : pathEntity.name;
     final String semanticsCount = '${pathEntity.assetCount}';
     return Selector<DefaultAssetPickerProvider, AssetPathEntity?>(
-      selector: (_, DefaultAssetPickerProvider p) => p.currentPathEntity,
+      selector: (_, DefaultAssetPickerProvider p) => p.currentPath,
       builder: (_, AssetPathEntity? currentPathEntity, __) {
         final bool isSelected = currentPathEntity == pathEntity;
         return Semantics(

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -16,11 +16,11 @@ import 'package:flutter/services.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:provider/provider.dart';
 
-import '../constants/colors.dart';
 import '../constants/constants.dart';
 import '../constants/enums.dart';
 import '../constants/extensions.dart';
 import '../delegates/asset_picker_text_delegate.dart';
+import '../internal/singleton.dart';
 import '../provider/asset_picker_provider.dart';
 import '../widget/asset_picker.dart';
 import '../widget/asset_picker_viewer.dart';
@@ -70,9 +70,10 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
           pickerTheme == null || themeColor == null,
           'Theme and theme color cannot be set at the same time.',
         ),
-        themeColor =
-            pickerTheme?.colorScheme.secondary ?? themeColor ?? C.themeColor {
-    Constants.textDelegate =
+        themeColor = pickerTheme?.colorScheme.secondary ??
+            themeColor ??
+            defaultThemeColorWeChat {
+    Singleton.textDelegate =
         textDelegate ?? assetPickerTextDelegateFromLocale(locale);
   }
 
@@ -204,13 +205,13 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
 
   bool get effectiveShouldRevertGrid => shouldRevertGrid ?? isAppleOS;
 
-  AssetPickerTextDelegate get textDelegate => Constants.textDelegate;
+  AssetPickerTextDelegate get textDelegate => Singleton.textDelegate;
 
   /// Keep a dispose method to sync with [State].
   /// 保留一个 dispose 方法与 [State] 同步。
   @mustCallSuper
   void dispose() {
-    Constants.scrollPosition = null;
+    Singleton.scrollPosition = null;
     gridScrollController.dispose();
     isSwitchingPath.dispose();
     permission.dispose();
@@ -652,7 +653,7 @@ class DefaultAssetPickerBuilderDelegate
     bool allowSpecialItemWhenEmpty = false,
     AssetSelectPredicate<AssetEntity>? selectPredicate,
     bool? shouldRevertGrid,
-    this.gridThumbSize = Constants.defaultGridThumbSize,
+    this.gridThumbSize = defaultAssetGridPreviewSize,
     this.previewThumbSize,
     this.specialPickerType,
     this.keepScrollOffset = false,
@@ -755,7 +756,7 @@ class DefaultAssetPickerBuilderDelegate
   /// 当 [keepScrollOffset] 为 true 时，跟踪 [gridScrollController] 位置的监听。
   void keepScrollOffsetListener() {
     if (gridScrollController.hasClients) {
-      Constants.scrollPosition = gridScrollController.position;
+      Singleton.scrollPosition = gridScrollController.position;
     }
   }
 
@@ -2063,11 +2064,11 @@ class DefaultAssetPickerBuilderDelegate
   Widget build(BuildContext context) {
     // Schedule the scroll position's restoration callback if this feature
     // is enabled and offsets are different.
-    if (keepScrollOffset && Constants.scrollPosition != null) {
+    if (keepScrollOffset && Singleton.scrollPosition != null) {
       SchedulerBinding.instance!.addPostFrameCallback((_) {
         // Update only if the controller has clients.
         if (gridScrollController.hasClients) {
-          gridScrollController.jumpTo(Constants.scrollPosition!.pixels);
+          gridScrollController.jumpTo(Singleton.scrollPosition!.pixels);
         }
       });
     }

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -2076,17 +2076,14 @@ class DefaultAssetPickerBuilderDelegate
       value: overlayStyle,
       child: Theme(
         data: theme,
-        child: CNP<DefaultAssetPickerProvider>.value(
-          value: provider,
-          builder: (BuildContext c, __) => Material(
-            color: theme.canvasColor,
-            child: Stack(
-              fit: StackFit.expand,
-              children: <Widget>[
-                if (isAppleOS) appleOSLayout(c) else androidLayout(c),
-                if (Platform.isIOS) iOSPermissionOverlay(c),
-              ],
-            ),
+        child: Material(
+          color: theme.canvasColor,
+          child: Stack(
+            fit: StackFit.expand,
+            children: <Widget>[
+              if (isAppleOS) appleOSLayout(context) else androidLayout(context),
+              if (Platform.isIOS) iOSPermissionOverlay(context),
+            ],
           ),
         ),
       ),

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -207,8 +207,13 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
 
   AssetPickerTextDelegate get textDelegate => Singleton.textDelegate;
 
-  /// Keep a dispose method to sync with [State].
-  /// 保留一个 dispose 方法与 [State] 同步。
+  /// Keep a `initState` method to sync with [State].
+  /// 保留一个 `initState` 方法与 [State] 同步。
+  @mustCallSuper
+  void initState(AssetPickerState<Asset, Path> state) {}
+
+  /// Keep a `dispose` method to sync with [State].
+  /// 保留一个 `dispose` 方法与 [State] 同步。
   @mustCallSuper
   void dispose() {
     Singleton.scrollPosition = null;

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -213,7 +213,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
 
   /// Called when assets changed and obtained notifications from the OS.
   /// 系统发出资源变更的通知时调用的方法
-  Future<void> onAssetsUpdated(MethodCall call, StateSetter setState) async {}
+  Future<void> onAssetsChanged(MethodCall call, StateSetter setState) async {}
 
   /// Keep a dispose method to sync with [State].
   /// 保留一个 dispose 方法与 [State] 同步。
@@ -793,7 +793,7 @@ class DefaultAssetPickerBuilderDelegate
   }
 
   @override
-  Future<void> onAssetsUpdated(MethodCall call, StateSetter setState) async {
+  Future<void> onAssetsChanged(MethodCall call, StateSetter setState) async {
     if (!isPermissionLimited) {
       return;
     }

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -23,10 +23,10 @@ import '../delegates/asset_picker_text_delegate.dart';
 import '../internal/singleton.dart';
 import '../provider/asset_picker_provider.dart';
 import '../widget/asset_picker.dart';
+import '../widget/asset_picker_app_bar.dart';
 import '../widget/asset_picker_viewer.dart';
 import '../widget/builder/asset_entity_grid_item_builder.dart';
 import '../widget/builder/value_listenable_builder_2.dart';
-import '../widget/fixed_appbar.dart';
 import '../widget/gaps.dart';
 import '../widget/platform_progress_indicator.dart';
 import '../widget/scale_text.dart';
@@ -870,7 +870,7 @@ class DefaultAssetPickerBuilderDelegate
 
   @override
   Widget androidLayout(BuildContext context) {
-    return FixedAppBarWrapper(
+    return AssetPickerAppBarWrapper(
       appBar: appBar(context),
       body: Selector<DefaultAssetPickerProvider, bool>(
         selector: (_, DefaultAssetPickerProvider provider) =>
@@ -906,7 +906,7 @@ class DefaultAssetPickerBuilderDelegate
 
   @override
   PreferredSizeWidget appBar(BuildContext context) {
-    return FixedAppBar(
+    return AssetPickerAppBar(
       backgroundColor: theme.appBarTheme.backgroundColor,
       centerTitle: isAppleOS,
       title: Semantics(

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -13,12 +13,12 @@ import 'package:flutter/services.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:provider/provider.dart';
 
-import '../constants/constants.dart';
 import '../constants/custom_scroll_physics.dart';
 import '../constants/enums.dart';
 import '../constants/extensions.dart';
 import '../delegates/asset_picker_builder_delegate.dart';
 import '../delegates/asset_picker_text_delegate.dart';
+import '../internal/singleton.dart';
 import '../provider/asset_picker_provider.dart';
 import '../provider/asset_picker_viewer_provider.dart';
 import '../widget/asset_picker_viewer.dart';
@@ -153,7 +153,7 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
   /// 当前平台是否为苹果系列系统
   bool get isAppleOS => Platform.isIOS || Platform.isMacOS;
 
-  AssetPickerTextDelegate get textDelegate => Constants.textDelegate;
+  AssetPickerTextDelegate get textDelegate => Singleton.textDelegate;
 
   /// Call when viewer is calling [initState].
   /// 当预览器调用 [initState] 时注册 [State] 和 [TickerProvider]。

--- a/lib/src/internal/methods.dart
+++ b/lib/src/internal/methods.dart
@@ -1,0 +1,15 @@
+///
+/// [Author] Alex (https://github.com/AlexV525)
+/// [Date] 2022/2/6 14:57
+///
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+
+/// Log only when debugging.
+/// 只在调试模式打印
+void realDebugPrint(dynamic message) {
+  if (!kReleaseMode) {
+    log('$message');
+  }
+}

--- a/lib/src/internal/singleton.dart
+++ b/lib/src/internal/singleton.dart
@@ -1,0 +1,24 @@
+///
+/// [Author] Alex (https://github.com/AlexV525)
+/// [Date] 2022/2/6 14:54
+///
+/// Define an inner static singleton for picker libraries.
+import 'package:flutter/widgets.dart';
+
+import '../delegates/asset_picker_text_delegate.dart';
+import '../delegates/sort_path_delegate.dart';
+
+class Singleton {
+  const Singleton._();
+
+  static GlobalKey pickerKey = GlobalKey();
+
+  static AssetPickerTextDelegate textDelegate = AssetPickerTextDelegate();
+  static SortPathDelegate<dynamic> sortPathDelegate = SortPathDelegate.common;
+
+  /// The last scroll position where the picker scrolled.
+  ///
+  /// See also:
+  ///  * [AssetPickerBuilderDelegate.keepScrollOffset]
+  static ScrollPosition? scrollPosition;
+}

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -8,8 +8,8 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 
-import '../constants/constants.dart';
 import '../delegates/sort_path_delegate.dart';
+import '../internal/singleton.dart';
 
 /// [ChangeNotifier] for assets picker.
 ///
@@ -239,7 +239,7 @@ class DefaultAssetPickerProvider
           pathThumbSize: pathThumbSize,
           selectedAssets: selectedAssets,
         ) {
-    Constants.sortPathDelegate = sortPathDelegate ?? SortPathDelegate.common;
+    Singleton.sortPathDelegate = sortPathDelegate ?? SortPathDelegate.common;
     // Call [getAssetList] with route duration when constructing.
     Future<void>.delayed(routeDuration).then(
       (dynamic _) async {
@@ -291,7 +291,7 @@ class DefaultAssetPickerProvider
     );
 
     // Sort path using sort path delegate.
-    Constants.sortPathDelegate.sort(_list);
+    Singleton.sortPathDelegate.sort(_list);
 
     for (final AssetPathEntity pathEntity in _list) {
       // Use sync method to avoid unnecessary wait.

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -47,7 +47,6 @@ abstract class AssetPickerProvider<Asset, Path> extends ChangeNotifier {
   @override
   void dispose() {
     _isAssetsEmpty = false;
-    _isSwitchingPath = false;
     _pathEntityList.clear();
     _currentPathEntity = null;
     _currentAssets.clear();
@@ -103,20 +102,6 @@ abstract class AssetPickerProvider<Asset, Path> extends ChangeNotifier {
       return;
     }
     _totalAssetsCount = value;
-    notifyListeners();
-  }
-
-  /// If path switcher opened.
-  /// 是否正在进行路径选择
-  bool _isSwitchingPath = false;
-
-  bool get isSwitchingPath => _isSwitchingPath;
-
-  set isSwitchingPath(bool value) {
-    if (value == _isSwitchingPath) {
-      return;
-    }
-    _isSwitchingPath = value;
     notifyListeners();
   }
 
@@ -390,7 +375,6 @@ class DefaultAssetPickerProvider
       return;
     }
     pathEntity ??= _currentPathEntity!;
-    _isSwitchingPath = false;
     _currentPathEntity = pathEntity;
     _totalAssetsCount = pathEntity.assetCount;
     notifyListeners();

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -6,7 +6,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:provider/provider.dart';
 
 import '../constants/constants.dart';
 import '../constants/enums.dart';
@@ -14,6 +13,8 @@ import '../constants/extensions.dart';
 import '../delegates/asset_picker_builder_delegate.dart';
 import '../delegates/asset_picker_text_delegate.dart';
 import '../delegates/sort_path_delegate.dart';
+import '../internal/methods.dart';
+import '../internal/singleton.dart';
 import '../provider/asset_picker_provider.dart';
 import 'asset_picker_page_route.dart';
 
@@ -37,7 +38,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
     List<AssetEntity>? selectedAssets,
     int maxAssets = 9,
     int pageSize = 80,
-    int gridThumbSize = Constants.defaultGridThumbSize,
+    int gridThumbSize = defaultAssetGridPreviewSize,
     int pathThumbSize = 80,
     int gridCount = 4,
     RequestType requestType = RequestType.image,
@@ -100,11 +101,10 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       filterOptions: filterOptions,
       routeDuration: routeDuration,
     );
-    final Widget picker =
-        ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+    final Widget picker = CNP<DefaultAssetPickerProvider>.value(
       value: provider,
       child: AssetPicker<AssetEntity, AssetPathEntity>(
-        key: Constants.pickerKey,
+        key: Singleton.pickerKey,
         builder: DefaultAssetPickerBuilderDelegate(
           provider: provider,
           initialPermission: _ps,
@@ -154,7 +154,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
     final Widget picker = CNP<PickerProvider>.value(
       value: provider,
       child: AssetPicker<Asset, Path>(
-        key: Constants.pickerKey,
+        key: Singleton.pickerKey,
         builder: delegate,
       ),
     );

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -310,28 +310,20 @@ class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
   void dispose() {
     WidgetsBinding.instance!.removeObserver(this);
     AssetPicker.unregisterObserve(_onLimitedAssetsUpdated);
-    // Skip delegate's dispose when it's keeping scroll offset.
-    if (!widget.builder.keepScrollOffset) {
-      widget.builder.dispose();
-    }
+    widget.builder.dispose();
     super.dispose();
   }
 
   Future<void> _onLimitedAssetsUpdated(MethodCall call) async {
-    if (!widget.builder.isPermissionLimited) {
-      return;
-    }
-    if (widget.builder.provider.currentPathEntity != null) {
-      final Path? _currentPathEntity =
-          widget.builder.provider.currentPathEntity;
-      if (_currentPathEntity is AssetPathEntity) {
-        await _currentPathEntity.refreshPathProperties();
-      }
-      await widget.builder.provider.switchPath(_currentPathEntity);
-      if (mounted) {
-        setState(() {});
-      }
-    }
+    await widget.builder.onAssetsUpdated(
+      call,
+      (VoidCallback fn) {
+        fn();
+        if (mounted) {
+          setState(() {});
+        }
+      },
+    );
   }
 
   @override

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -288,12 +288,13 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
 }
 
 class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
-    with WidgetsBindingObserver {
+    with TickerProviderStateMixin, WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance!.addObserver(this);
     AssetPicker.registerObserve(_onLimitedAssetsUpdated);
+    widget.builder.initState(this);
   }
 
   @override

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -315,7 +315,7 @@ class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
   }
 
   Future<void> _onLimitedAssetsUpdated(MethodCall call) async {
-    await widget.builder.onAssetsUpdated(
+    await widget.builder.onAssetsChanged(
       call,
       (VoidCallback fn) {
         fn();

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -144,19 +144,15 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       PickerProvider extends AssetPickerProvider<Asset, Path>>(
     BuildContext context, {
     required AssetPickerBuilderDelegate<Asset, Path> delegate,
-    required PickerProvider provider,
     bool useRootNavigator = true,
     Curve routeCurve = Curves.easeIn,
     Duration routeDuration = const Duration(milliseconds: 300),
   }) async {
     await permissionCheck();
 
-    final Widget picker = CNP<PickerProvider>.value(
-      value: provider,
-      child: AssetPicker<Asset, Path>(
-        key: Singleton.pickerKey,
-        builder: delegate,
-      ),
+    final Widget picker = AssetPicker<Asset, Path>(
+      key: Singleton.pickerKey,
+      builder: delegate,
     );
     final List<Asset>? result = await Navigator.of(
       context,

--- a/lib/src/widget/asset_picker_app_bar.dart
+++ b/lib/src/widget/asset_picker_app_bar.dart
@@ -151,12 +151,11 @@ class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
 
     // Allow custom blur radius using [ui.ImageFilter.blur].
     if (blurRadius > 0.0) {
-      child = ImageFiltered(
-        imageFilter: ui.ImageFilter.blur(
-          sigmaX: blurRadius,
-          sigmaY: blurRadius,
+      child = ClipRect(
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(sigmaX: blurRadius, sigmaY: blurRadius),
+          child: child,
         ),
-        child: child,
       );
     }
 

--- a/lib/src/widget/asset_picker_app_bar.dart
+++ b/lib/src/widget/asset_picker_app_bar.dart
@@ -11,8 +11,8 @@ import '../constants/extensions.dart';
 
 /// A custom app bar.
 /// 自定义的顶栏
-class FixedAppBar extends StatelessWidget implements PreferredSizeWidget {
-  const FixedAppBar({
+class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const AssetPickerAppBar({
     Key? key,
     this.automaticallyImplyLeading = true,
     this.title,
@@ -51,7 +51,7 @@ class FixedAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// 是否会自动检测并添加返回按钮至头部
   final bool automaticallyImplyLeading;
 
-  /// Whether the [title] should be at the center of the [FixedAppBar].
+  /// Whether the [title] should be at the center of the [AssetPickerAppBar].
   /// [title] 是否会在正中间
   final bool centerTitle;
 
@@ -167,10 +167,10 @@ class FixedAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-/// Wrapper for [FixedAppBar]. Avoid elevation covered by body.
+/// Wrapper for [AssetPickerAppBar]. Avoid elevation covered by body.
 /// 顶栏封装。防止内容块层级高于顶栏导致遮挡阴影。
-class FixedAppBarWrapper extends StatelessWidget {
-  const FixedAppBarWrapper({
+class AssetPickerAppBarWrapper extends StatelessWidget {
+  const AssetPickerAppBarWrapper({
     Key? key,
     required this.appBar,
     required this.body,

--- a/lib/src/widget/asset_picker_app_bar.dart
+++ b/lib/src/widget/asset_picker_app_bar.dart
@@ -7,27 +7,28 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../constants/extensions.dart';
-
 /// A custom app bar.
 /// 自定义的顶栏
 class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
   const AssetPickerAppBar({
     Key? key,
     this.automaticallyImplyLeading = true,
+    this.automaticallyImplyActions = true,
+    this.brightness,
     this.title,
     this.leading,
+    this.bottom,
     this.centerTitle = true,
     this.backgroundColor,
-    this.elevation,
+    this.elevation = 0,
     this.actions,
     this.actionsPadding,
-    this.bottom,
     this.height,
-    this.blurRadius = 0.0,
+    this.blurRadius = 0,
+    this.iconTheme,
   }) : super(key: key);
 
-  /// Title widget.
+  /// Title widget. Typically a [Text] widget.
   /// 标题部件
   final Widget? title;
 
@@ -39,71 +40,83 @@ class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// 尾部操作部件
   final List<Widget>? actions;
 
-  /// Padding for actions.
-  /// 尾部操作部分的内边距
-  final EdgeInsetsDirectional? actionsPadding;
-
   /// This widget appears across the bottom of the app bar.
   /// 显示在顶栏下方的 widget
   final PreferredSizeWidget? bottom;
+
+  /// Padding for actions.
+  /// 尾部操作部分的内边距
+  final EdgeInsetsGeometry? actionsPadding;
 
   /// Whether it should imply leading with [BackButton] automatically.
   /// 是否会自动检测并添加返回按钮至头部
   final bool automaticallyImplyLeading;
 
-  /// Whether the [title] should be at the center of the [AssetPickerAppBar].
+  /// Whether the [title] should be at the center of the [FixedAppBar].
   /// [title] 是否会在正中间
   final bool centerTitle;
+
+  /// Whether it should imply actions size with [effectiveHeight].
+  /// 是否会自动使用 [effectiveHeight] 进行占位
+  final bool automaticallyImplyActions;
 
   /// Background color.
   /// 背景颜色
   final Color? backgroundColor;
 
-  /// The size of the shadow below the app bar.
-  /// 底部阴影的大小
-  final double? elevation;
-
   /// Height of the app bar.
   /// 高度
   final double? height;
 
-  /// Value that can enable the app bar using filter with [ui.ImageFilter]
-  /// 实现高斯模糊效果的值
+  /// Elevation to [Material].
+  /// 设置在 [Material] 的阴影
+  final double elevation;
+
+  /// The blur radius applies on the bar.
+  /// 顶栏的高斯模糊值
   final double blurRadius;
 
-  double get _effectiveHeight => height ?? kToolbarHeight;
+  /// Set the brightness for the status bar's layer.
+  /// 设置状态栏亮度层
+  final Brightness? brightness;
+
+  final IconThemeData? iconTheme;
+
+  bool canPop(BuildContext context) =>
+      Navigator.of(context).canPop() && automaticallyImplyLeading;
+
+  double get _barHeight => height ?? kToolbarHeight;
+
+  double get effectiveHeight =>
+      _barHeight + (bottom?.preferredSize.height ?? 0);
 
   @override
-  Size get preferredSize => Size.fromHeight(_effectiveHeight);
+  Size get preferredSize => Size.fromHeight(effectiveHeight);
 
   @override
   Widget build(BuildContext context) {
-    final Color color = (backgroundColor ?? Theme.of(context).primaryColor)
-        .withOpacity(blurRadius > 0.0 ? 0.90 : 1.0);
-
     Widget? _title = title;
     if (centerTitle) {
       _title = Center(child: _title);
     }
-
     Widget child = Container(
       width: double.maxFinite,
-      height: (height ?? kToolbarHeight) + MediaQuery.of(context).padding.top,
-      padding: EdgeInsetsDirectional.only(
-        top: MediaQuery.of(context).padding.top,
-      ),
+      height: _barHeight + MediaQuery.of(context).padding.top,
+      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
       child: Stack(
         children: <Widget>[
-          if (automaticallyImplyLeading && Navigator.of(context).canPop())
-            leading ?? const BackButton(),
+          if (canPop(context))
+            PositionedDirectional(
+              top: 0.0,
+              bottom: 0.0,
+              child: leading ?? const BackButton(),
+            ),
           if (_title != null)
             PositionedDirectional(
               top: 0.0,
               bottom: 0.0,
-              start: automaticallyImplyLeading && Navigator.of(context).canPop()
-                  ? _effectiveHeight
-                  : 0.0,
-              end: _effectiveHeight,
+              start: canPop(context) ? _barHeight : 0.0,
+              end: automaticallyImplyActions ? _barHeight : 0.0,
               child: Align(
                 alignment: centerTitle
                     ? Alignment.center
@@ -120,14 +133,13 @@ class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ),
               ),
             ),
-          if (automaticallyImplyLeading &&
-              Navigator.of(context).canPop() &&
-              (actions?.isEmpty ?? true))
-            const SizedBox(width: kMinInteractiveDimension)
-          else if (actions?.isNotEmpty == true)
+          if (canPop(context) && (actions?.isEmpty ?? true))
+            SizedBox(width: _barHeight)
+          else if (actions?.isNotEmpty ?? false)
             PositionedDirectional(
+              top: 0.0,
               end: 0.0,
-              height: kToolbarHeight,
+              height: _barHeight,
               child: Padding(
                 padding: actionsPadding ?? EdgeInsets.zero,
                 child: Row(mainAxisSize: MainAxisSize.min, children: actions!),
@@ -137,32 +149,47 @@ class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
       ),
     );
 
+    // Allow custom blur radius using [ui.ImageFilter.blur].
     if (blurRadius > 0.0) {
-      child = ClipRect(
-        child: BackdropFilter(
-          filter: ui.ImageFilter.blur(sigmaX: blurRadius, sigmaY: blurRadius),
-          child: child,
+      child = ImageFiltered(
+        imageFilter: ui.ImageFilter.blur(
+          sigmaX: blurRadius,
+          sigmaY: blurRadius,
         ),
+        child: child,
       );
     }
 
-    final ThemeData themeData = Theme.of(context);
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: themeData.appBarTheme.systemOverlayStyle ??
-          (themeData.effectiveBrightness.isDark
-              ? SystemUiOverlayStyle.light
-              : SystemUiOverlayStyle.dark),
-      child: Material(
-        type: color.isTransparent
-            ? MaterialType.transparency
-            : MaterialType.canvas,
-        color: (backgroundColor ??
-                context.themeData.appBarTheme.backgroundColor ??
-                context.themeData.primaryColor)
-            .withOpacity(blurRadius > 0.0 ? 0.90 : 1.0),
-        elevation: elevation ?? context.themeData.appBarTheme.elevation ?? 4.0,
-        child: child,
+    if (iconTheme != null) {
+      child = IconTheme.merge(data: iconTheme!, child: child);
+    }
+
+    // Set [SystemUiOverlayStyle] according to the brightness.
+    final Brightness _effectiveBrightness = brightness ??
+        Theme.of(context).appBarTheme.systemOverlayStyle?.statusBarBrightness ??
+        Theme.of(context).brightness;
+    child = AnnotatedRegion<SystemUiOverlayStyle>(
+      value: _effectiveBrightness == Brightness.dark
+          ? SystemUiOverlayStyle.light
+          : SystemUiOverlayStyle.dark,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          child,
+          if (bottom != null) bottom!,
+        ],
       ),
+    );
+
+    // Wrap with a [Material] to ensure the child rendered correctly.
+    return Material(
+      color: Color.lerp(
+        backgroundColor ?? Theme.of(context).colorScheme.surface,
+        Colors.transparent,
+        blurRadius > 0.0 ? 0.1 : 0.0,
+      ),
+      elevation: elevation,
+      child: child,
     );
   }
 }
@@ -176,7 +203,7 @@ class AssetPickerAppBarWrapper extends StatelessWidget {
     required this.body,
   }) : super(key: key);
 
-  final PreferredSizeWidget appBar;
+  final AssetPickerAppBar appBar;
   final Widget body;
 
   @override

--- a/lib/src/widget/builder/asset_entity_grid_item_builder.dart
+++ b/lib/src/widget/builder/asset_entity_grid_item_builder.dart
@@ -6,7 +6,7 @@ import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 
-import '../../constants/constants.dart';
+import '../../internal/singleton.dart';
 import '../../widget/scale_text.dart';
 
 class AssetEntityGridItemBuilder extends StatefulWidget {
@@ -25,13 +25,11 @@ class AssetEntityGridItemBuilder extends StatefulWidget {
 }
 
 class AssetEntityGridItemWidgetState extends State<AssetEntityGridItemBuilder> {
-  AssetEntityImageProvider get imageProvider => widget.image;
-
   Widget? child;
 
   Widget get newChild {
     return ExtendedImage(
-      image: imageProvider,
+      image: widget.image,
       fit: BoxFit.cover,
       loadStateChanged: (ExtendedImageState state) {
         Widget loader = const SizedBox.shrink();
@@ -56,7 +54,7 @@ class AssetEntityGridItemWidgetState extends State<AssetEntityGridItemBuilder> {
   Widget failedItemBuilder(BuildContext context) {
     return Center(
       child: ScaleText(
-        Constants.textDelegate.loadFailed,
+        Singleton.textDelegate.loadFailed,
         textAlign: TextAlign.center,
         style: const TextStyle(fontSize: 18.0),
       ),

--- a/lib/src/widget/builder/audio_page_builder.dart
+++ b/lib/src/widget/builder/audio_page_builder.dart
@@ -8,8 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:video_player/video_player.dart';
 
-import '../../constants/constants.dart';
 import '../../constants/extensions.dart';
+import '../../internal/methods.dart';
+import '../../internal/singleton.dart';
 import '../scale_text.dart';
 
 class AudioPageBuilder extends StatefulWidget {
@@ -143,9 +144,9 @@ class _AudioPageBuilderState extends State<AudioPageBuilder> {
       stream: durationStreamController.stream,
       builder: (BuildContext _, AsyncSnapshot<Duration> data) {
         return ScaleText(
-          '${Constants.textDelegate.durationIndicatorBuilder(data.data!)}'
+          '${Singleton.textDelegate.durationIndicatorBuilder(data.data!)}'
           ' / '
-          '${Constants.textDelegate.durationIndicatorBuilder(assetDuration)}',
+          '${Singleton.textDelegate.durationIndicatorBuilder(assetDuration)}',
           style: const TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.normal,
@@ -159,7 +160,7 @@ class _AudioPageBuilderState extends State<AudioPageBuilder> {
   Widget build(BuildContext context) {
     return Semantics(
       onLongPress: playButtonCallback,
-      onLongPressHint: Constants.textDelegate.sActionPlayHint,
+      onLongPressHint: Singleton.textDelegate.sActionPlayHint,
       child: ColoredBox(
         color: context.themeData.backgroundColor,
         child: isLoaded

--- a/lib/src/widget/builder/video_page_builder.dart
+++ b/lib/src/widget/builder/video_page_builder.dart
@@ -8,8 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:video_player/video_player.dart';
 
-import '../../constants/constants.dart';
 import '../../delegates/asset_picker_viewer_builder_delegate.dart';
+import '../../internal/methods.dart';
+import '../../internal/singleton.dart';
 import '../scale_text.dart';
 import 'locally_available_builder.dart';
 
@@ -195,7 +196,7 @@ class _VideoPageBuilderState extends State<VideoPageBuilder> {
       asset: widget.asset,
       builder: (BuildContext context, AssetEntity asset) {
         if (hasErrorWhenInitializing) {
-          return Center(child: ScaleText(Constants.textDelegate.loadFailed));
+          return Center(child: ScaleText(Singleton.textDelegate.loadFailed));
         }
         if (!_isLocallyAvailable && !_isInitializing) {
           initializeVideoPlayerController();
@@ -205,7 +206,7 @@ class _VideoPageBuilderState extends State<VideoPageBuilder> {
         }
         return Semantics(
           onLongPress: playButtonCallback,
-          onLongPressHint: Constants.textDelegate.sActionPlayHint,
+          onLongPressHint: Singleton.textDelegate.sActionPlayHint,
           child: GestureDetector(
             onLongPress: MediaQuery.of(context).accessibleNavigation
                 ? playButtonCallback

--- a/lib/wechat_assets_picker.dart
+++ b/lib/wechat_assets_picker.dart
@@ -2,6 +2,7 @@ library wechat_assets_picker;
 
 export 'package:photo_manager/photo_manager.dart';
 
+export 'src/constants/constants.dart';
 export 'src/constants/enums.dart';
 export 'src/delegates/asset_picker_builder_delegate.dart';
 export 'src/delegates/asset_picker_text_delegate.dart';

--- a/lib/wechat_assets_picker.dart
+++ b/lib/wechat_assets_picker.dart
@@ -11,6 +11,7 @@ export 'src/delegates/sort_path_delegate.dart';
 export 'src/provider/asset_picker_provider.dart';
 export 'src/provider/asset_picker_viewer_provider.dart';
 export 'src/widget/asset_picker.dart';
+export 'src/widget/asset_picker_app_bar.dart';
 export 'src/widget/asset_picker_page_route.dart';
 export 'src/widget/asset_picker_viewer.dart';
 export 'src/widget/builder/asset_entity_grid_item_builder.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
 
   extended_image: ^6.0.1
+  meta: ^1.7.0
   photo_manager: ^2.0.0-dev.3
   provider: ^6.0.1
   video_player: ^2.2.14


### PR DESCRIPTION
See #237.

Changes:
- Expose `defaultThemeColorWeChat`, `defaultAssetGridPreviewSize`.
- Expose `AssetPickerAppBar`.
- Split inner singleton and constants.
- Add `AssetPickerBuilderDelegate.initState`.
- Add `AssetPickerBuilderDelegate.onAssetsChanged`.
- Add `AssetPickerProvider.setPathThumbnail`.
- Use `meta` package explicitly.

Breaking changes:

- `provider` is removed from `AssetPicker.pickAssetsWithDelegate`.
- `AssetPickerProvider` is no longer exists at the ancestors of `AssetPickerBuilderDelegate`, delegates should provide their own providers manually.
- `keepScrollOffset` is moved from `AssetPickerBuilderDelegate` to `DefaultAssetPickerBuilderDelegate`.
- `isSingleAssetMode` is now an abstract field in `AssetPickerBuilderDelegate`.
- `build` is now an abstract method in `AssetPickerBuilderDelegate`.
- `isSwitchingPath` is moved from `AssetPickerProvider` to `AssetPickerBuilderDelegate`.
- `currentPathEntity` is renamed to `currentPath` in `AssetPickerProvider`.
- `pathEntityList` is renamed to `pathsList` in `AssetPickerProvider`.
- `validPathThumbCount` is renamed to `validPathThumbnailsCount` in `AssetPickerProvider`.
- `getAssetPathList` is renamed to `getPaths` in `AssetPickerProvider`.
- `getAssetsFromEntity` is renamed to `getAssetsFromPath` in `AssetPickerProvider`.
- `getFirstThumbFromPathEntity` is renamed to `getThumbnailFromPath` in `AssetPickerProvider`.
- `getAssetList` is renamed to `getAssetsFromCurrentPath` in `DefaultAssetPickerProvider`.