### PR TITLE
🚀 Extend page route

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -190,8 +190,7 @@ platform :ios, '9.0'
 | allowSpecialItemWhenEmpty | `bool`                             | 在资源为空时是否允许显示自定义item                            | `false`                             |
 | selectPredicate           | `AssetSelectPredicate`             | 判断资源可否被选择                                      | `null`                              |
 | shouldRevertGrid          | `bool?`                            | 判断资源网格是否需要倒序排列                                 | `null`                              |
-| routeCurve                | `Curve`                            | 选择构造路由动画的曲线                                    | `Curves.easeIn`                     |
-| routeDuration             | `Duration`                         | 选择构造路由动画的时间                                    | `const Duration(milliseconds: 500)` |
+| pageRouteBuilder          | `AssetPickerPageRouteBuilder`      | 构建 `AssetPickerPageRoute`                      | `null`                              |
 
 ### 简单的使用方法
 

--- a/README.md
+++ b/README.md
@@ -162,30 +162,29 @@ platform :osx, '10.15'
 
 ## Usage 📖
 
-| Name                      | Type                        | Description                                                                                                         | Default                             |
-|---------------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| selectedAssets            | `List<AssetEntity>?`        | Selected assets. Prevent duplicate selection. If you don't need to prevent duplicate selection, just don't pass it. | `null`                              |
-| maxAssets                 | `int`                       | Maximum asset that the picker can pick.                                                                             | 9                                   |
-| pageSize                  | `int?`                      | Number of assets per page. **Must be a multiple of `gridCount`**.                                                   | 320 (80 * 4)                        |
-| gridThumbSize             | `int`                       | Thumbnail size for the grid's item.                                                                                 | 200                                 |
-| pathThumbSize             | `int`                       | Thumbnail size for the path selector.                                                                               | 80                                  |
-| previewThumbSize          | `List<int>?`                | Preview thumbnail size in the viewer.                                                                               | `null`                              |
-| gridCount                 | `int`                       | Grid count in picker.                                                                                               | 4                                   |
-| requestType               | `RequestType`               | Request type for picker.                                                                                            | `RequestType.image`                 |
-| specialPickerType         | `SpacialPickerType?`        | Provides the option to integrate a custom picker type.                                                              | `null`                              |
-| themeColor                | `Color?`                    | Main theme color for the picker.                                                                                    | `Color(0xff00bc56)`                 |
-| pickerTheme               | `ThemeData?`                | Theme data provider for the picker and the viewer.                                                                  | `null`                              |
-| sortPathDelegate          | `SortPathDeleage?`          | Path entities sort delegate for the picker, sort paths as you want.                                                 | `CommonSortPathDelegate`            |
-| textDelegate              | `AssetsPickerTextDelegate?` | Text delegate for the picker, for customize the texts.                                                              | `DefaultAssetsPickerTextDelegate()` |
-| filterOptions             | `FilterOptionGroup?`        | Allow users to customize assets filter options.                                                                     | `null`                              |
-| specialItemBuilder        | `WidgetBuilder?`            | The widget builder for the special item.                                                                            | `null`                              |
-| specialItemPosition       | `SpecialItemPosition`       | Allow users set a special item in the picker with several positions.                                                | `SpecialItemPosition.none`          |
-| loadingIndicatorBuilder   | `IndicatorBuilder?`         | Indicates the loading status for the builder.                                                                       | `null`                              |
-| allowSpecialItemWhenEmpty | `bool`                      | Whether the special item will display or not when assets is empty.                                                  | `false`                             |
-| selectPredicate           | `AssetSelectPredicate`      | Predicate whether an asset can be selected or unselected.                                                           | `null`                              |
-| shouldRevertGrid          | `bool?`                     | Whether the assets grid should revert.                                                                              | `null`                              |
-| routeCurve                | `Curve`                     | The curve which the picker use to build page route transition.                                                      | `Curves.easeIn`                     |
-| routeDuration             | `Duration`                  | The duration which the picker use to build page route transition.                                                   | `const Duration(milliseconds: 500)` |
+| Name                      | Type                          | Description                                                                                                         | Default                             |
+|---------------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| selectedAssets            | `List<AssetEntity>?`          | Selected assets. Prevent duplicate selection. If you don't need to prevent duplicate selection, just don't pass it. | `null`                              |
+| maxAssets                 | `int`                         | Maximum asset that the picker can pick.                                                                             | 9                                   |
+| pageSize                  | `int?`                        | Number of assets per page. **Must be a multiple of `gridCount`**.                                                   | 320 (80 * 4)                        |
+| gridThumbSize             | `int`                         | Thumbnail size for the grid's item.                                                                                 | 200                                 |
+| pathThumbSize             | `int`                         | Thumbnail size for the path selector.                                                                               | 80                                  |
+| previewThumbSize          | `List<int>?`                  | Preview thumbnail size in the viewer.                                                                               | `null`                              |
+| gridCount                 | `int`                         | Grid count in picker.                                                                                               | 4                                   |
+| requestType               | `RequestType`                 | Request type for picker.                                                                                            | `RequestType.image`                 |
+| specialPickerType         | `SpacialPickerType?`          | Provides the option to integrate a custom picker type.                                                              | `null`                              |
+| themeColor                | `Color?`                      | Main theme color for the picker.                                                                                    | `Color(0xff00bc56)`                 |
+| pickerTheme               | `ThemeData?`                  | Theme data provider for the picker and the viewer.                                                                  | `null`                              |
+| sortPathDelegate          | `SortPathDeleage?`            | Path entities sort delegate for the picker, sort paths as you want.                                                 | `CommonSortPathDelegate`            |
+| textDelegate              | `AssetsPickerTextDelegate?`   | Text delegate for the picker, for customize the texts.                                                              | `DefaultAssetsPickerTextDelegate()` |
+| filterOptions             | `FilterOptionGroup?`          | Allow users to customize assets filter options.                                                                     | `null`                              |
+| specialItemBuilder        | `WidgetBuilder?`              | The widget builder for the special item.                                                                            | `null`                              |
+| specialItemPosition       | `SpecialItemPosition`         | Allow users set a special item in the picker with several positions.                                                | `SpecialItemPosition.none`          |
+| loadingIndicatorBuilder   | `IndicatorBuilder?`           | Indicates the loading status for the builder.                                                                       | `null`                              |
+| allowSpecialItemWhenEmpty | `bool`                        | Whether the special item will display or not when assets is empty.                                                  | `false`                             |
+| selectPredicate           | `AssetSelectPredicate`        | Predicate whether an asset can be selected or unselected.                                                           | `null`                              |
+| shouldRevertGrid          | `bool?`                       | Whether the assets grid should revert.                                                                              | `null`                              |
+| pageRouteBuilder          | `AssetPickerPageRouteBuilder` | Build `AssetPickerPageRoute` with the given generic type.                                                           | `null`                              |
 
 ### Simple usage
 

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -232,7 +232,6 @@ class DefaultAssetPickerProvider
     int maxAssets = 9,
     int pageSize = 80,
     int pathThumbSize = 80,
-    Duration routeDuration = const Duration(milliseconds: 300),
   }) : super(
           maxAssets: maxAssets,
           pageSize: pageSize,
@@ -241,12 +240,10 @@ class DefaultAssetPickerProvider
         ) {
     Singleton.sortPathDelegate = sortPathDelegate ?? SortPathDelegate.common;
     // Call [getAssetList] with route duration when constructing.
-    Future<void>.delayed(routeDuration).then(
-      (dynamic _) async {
-        await getPaths();
-        await getAssetsFromCurrentPath();
-      },
-    );
+    Future<void>(() async {
+      await getPaths();
+      await getAssetsFromCurrentPath();
+    });
   }
 
   /// Request assets type.

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -56,8 +56,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
     AssetSelectPredicate<AssetEntity>? selectPredicate,
     bool? shouldRevertGrid,
     bool useRootNavigator = true,
-    Curve routeCurve = Curves.easeIn,
-    Duration routeDuration = const Duration(milliseconds: 300),
+    AssetPickerPageRouteBuilder<List<AssetEntity>>? pageRouteBuilder,
   }) async {
     if (maxAssets < 1) {
       throw ArgumentError(
@@ -99,7 +98,6 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       requestType: requestType,
       sortPathDelegate: sortPathDelegate,
       filterOptions: filterOptions,
-      routeDuration: routeDuration,
     );
     final Widget picker = CNP<DefaultAssetPickerProvider>.value(
       value: provider,
@@ -129,24 +127,20 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       context,
       rootNavigator: useRootNavigator,
     ).push<List<AssetEntity>>(
-      AssetPickerPageRoute<List<AssetEntity>>(
-        builder: picker,
-        transitionCurve: routeCurve,
-        transitionDuration: routeDuration,
-      ),
+      pageRouteBuilder?.call(picker) ??
+          AssetPickerPageRoute<List<AssetEntity>>(builder: (_) => picker),
     );
     return result;
   }
 
-  /// Call the picker with provided [delegate] and [provider].
-  /// 通过指定的 [delegate] 和 [provider] 调用选择器
+  /// Call the picker with provided [delegate].
+  /// 通过指定的 [delegate] 调用选择器
   static Future<List<Asset>?> pickAssetsWithDelegate<Asset, Path,
       PickerProvider extends AssetPickerProvider<Asset, Path>>(
     BuildContext context, {
     required AssetPickerBuilderDelegate<Asset, Path> delegate,
     bool useRootNavigator = true,
-    Curve routeCurve = Curves.easeIn,
-    Duration routeDuration = const Duration(milliseconds: 300),
+    AssetPickerPageRouteBuilder<List<Asset>>? pageRouteBuilder,
   }) async {
     await permissionCheck();
 
@@ -158,11 +152,8 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       context,
       rootNavigator: useRootNavigator,
     ).push<List<Asset>>(
-      AssetPickerPageRoute<List<Asset>>(
-        builder: picker,
-        transitionCurve: routeCurve,
-        transitionDuration: routeDuration,
-      ),
+      pageRouteBuilder?.call(picker) ??
+          AssetPickerPageRoute<List<Asset>>(builder: (_) => picker),
     );
     return result;
   }

--- a/lib/src/widget/asset_picker_page_route.dart
+++ b/lib/src/widget/asset_picker_page_route.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 /// Build [AssetPickerPageRoute] with the given generic type.
+/// 构建匹配泛型的 [AssetPickerPageRoute]
 typedef AssetPickerPageRouteBuilder<T> = AssetPickerPageRoute<T> Function(
   Widget picker,
 );

--- a/lib/src/widget/asset_picker_page_route.dart
+++ b/lib/src/widget/asset_picker_page_route.dart
@@ -4,6 +4,11 @@
 ///
 import 'package:flutter/material.dart';
 
+/// Build [AssetPickerPageRoute] with the given generic type.
+typedef AssetPickerPageRouteBuilder<T> = AssetPickerPageRoute<T> Function(
+  Widget picker,
+);
+
 /// Built a slide page transition for the picker.
 /// 为选择器构造一个上下进出的页面过渡动画
 class AssetPickerPageRoute<T> extends PageRoute<T> {
@@ -11,29 +16,29 @@ class AssetPickerPageRoute<T> extends PageRoute<T> {
     required this.builder,
     this.transitionCurve = Curves.easeIn,
     this.transitionDuration = const Duration(milliseconds: 500),
+    this.barrierColor,
+    this.barrierDismissible = false,
+    this.barrierLabel,
+    this.maintainState = true,
+    this.opaque = true,
   });
 
-  final Widget builder;
+  final WidgetBuilder builder;
 
   final Curve transitionCurve;
-
   @override
   final Duration transitionDuration;
 
   @override
-  final bool opaque = true;
-
+  final Color? barrierColor;
   @override
-  final bool barrierDismissible = false;
-
+  final bool barrierDismissible;
   @override
-  final bool maintainState = true;
-
+  final String? barrierLabel;
   @override
-  Color? get barrierColor => null;
-
+  final bool opaque;
   @override
-  String? get barrierLabel => null;
+  final bool maintainState;
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) => false;
@@ -44,7 +49,7 @@ class AssetPickerPageRoute<T> extends PageRoute<T> {
     Animation<double> animation,
     Animation<double> secondaryAnimation,
   ) {
-    return builder;
+    return builder(context);
   }
 
   @override


### PR DESCRIPTION
Resolves #247.

Breaking changes:
- `routeCurve` and `routeDuration` are removed, instead with `pageRouteBuilder`.
- `DefaultAssetPickerProvider` no longer waits 300ms for initializations.