### PR TITLE
🚀 Support predictable special item display

### DIFF
--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -86,7 +86,14 @@ class PickMethod {
             selectedAssets: assets,
             requestType: RequestType.common,
             specialItemPosition: SpecialItemPosition.prepend,
-            specialItemBuilder: (BuildContext context) {
+            specialItemBuilder: (
+              BuildContext context,
+              AssetPathEntity? path,
+              int length,
+            ) {
+              if (path?.isAll != true) {
+                return null;
+              }
               return Semantics(
                 label: AssetPickerTextDelegate().sActionUseCameraHint,
                 button: true,
@@ -130,7 +137,14 @@ class PickMethod {
             selectedAssets: assets,
             requestType: RequestType.common,
             specialItemPosition: SpecialItemPosition.prepend,
-            specialItemBuilder: (BuildContext context) {
+            specialItemBuilder: (
+              BuildContext context,
+              AssetPathEntity? path,
+              int length,
+            ) {
+              if (path?.isAll != true) {
+                return null;
+              }
               return Semantics(
                 label: AssetPickerTextDelegate().sActionUseCameraHint,
                 button: true,
@@ -247,7 +261,11 @@ class PickMethod {
             selectedAssets: assets,
             requestType: RequestType.common,
             specialItemPosition: SpecialItemPosition.prepend,
-            specialItemBuilder: (BuildContext context) {
+            specialItemBuilder: (
+              BuildContext context,
+              AssetPathEntity? path,
+              int length,
+            ) {
               return const Center(
                 child: Text('Custom Widget', textAlign: TextAlign.center),
               );

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -4,9 +4,9 @@
 ///
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:wechat_assets_picker/src/delegates/asset_picker_text_delegate.dart';
 
-import '../delegates/asset_picker_builder_delegate.dart';
+import '../constants/typedefs.dart';
+import '../delegates/asset_picker_text_delegate.dart';
 import '../delegates/sort_path_delegate.dart';
 import 'constants.dart';
 import 'enums.dart';
@@ -31,7 +31,6 @@ class AssetPickerConfig {
     this.specialItemPosition = SpecialItemPosition.none,
     this.specialItemBuilder,
     this.loadingIndicatorBuilder,
-    this.allowSpecialItemWhenEmpty = false,
     this.selectPredicate,
     this.shouldRevertGrid,
   })  : assert(maxAssets >= 1, 'maxAssets must be greater than 1.'),
@@ -159,15 +158,11 @@ class AssetPickerConfig {
 
   /// The widget builder for the the special item.
   /// 自定义item的构造方法
-  final WidgetBuilder? specialItemBuilder;
+  final SpecialItemBuilder<AssetPathEntity>? specialItemBuilder;
 
   /// Indicates the loading status for the builder.
   /// 指示目前加载的状态
-  final IndicatorBuilder? loadingIndicatorBuilder;
-
-  /// Whether the special item will display or not when assets is empty.
-  /// 当没有资源时是否显示自定义item
-  final bool allowSpecialItemWhenEmpty;
+  final LoadingIndicatorBuilder? loadingIndicatorBuilder;
 
   /// {@macro wechat_assets_picker.AssetSelectPredicate}
   final AssetSelectPredicate<AssetEntity>? selectPredicate;

--- a/lib/src/constants/typedefs.dart
+++ b/lib/src/constants/typedefs.dart
@@ -1,0 +1,32 @@
+///
+/// [Author] Alex (https://github.com/AlexV525)
+/// [Date] 2022/3/3 09:55
+///
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+typedef LoadingIndicatorBuilder = Widget Function(
+  BuildContext context,
+  bool isAssetsEmpty,
+);
+
+/// {@template wechat_assets_picker.AssetSelectPredicate}
+/// Predicate whether an asset can be selected or unselected.
+/// 判断资源可否被选择
+/// {@endtemplate}
+typedef AssetSelectPredicate<Asset> = FutureOr<bool> Function(
+  BuildContext context,
+  Asset asset,
+  bool isSelected,
+);
+
+/// {@template wechat_asset_picker.SpecialItemBuilder}
+/// Build the special item according the given path and assets length.
+/// 根据给定的目录和资源数量构建特殊 item
+/// {@endtemplate}
+typedef SpecialItemBuilder<Path> = Widget? Function(
+  BuildContext context,
+  Path? path,
+  int length,
+);

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -16,7 +16,7 @@ import 'package:provider/provider.dart';
 import '../constants/custom_scroll_physics.dart';
 import '../constants/enums.dart';
 import '../constants/extensions.dart';
-import '../delegates/asset_picker_builder_delegate.dart';
+import '../constants/typedefs.dart';
 import '../delegates/asset_picker_text_delegate.dart';
 import '../internal/singleton.dart';
 import '../provider/asset_picker_provider.dart';

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -59,7 +59,6 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
         specialItemPosition: pickerConfig.specialItemPosition,
         specialItemBuilder: pickerConfig.specialItemBuilder,
         loadingIndicatorBuilder: pickerConfig.loadingIndicatorBuilder,
-        allowSpecialItemWhenEmpty: pickerConfig.allowSpecialItemWhenEmpty,
         selectPredicate: pickerConfig.selectPredicate,
         shouldRevertGrid: pickerConfig.shouldRevertGrid,
         textDelegate: pickerConfig.textDelegate,

--- a/lib/src/widget/asset_picker_viewer.dart
+++ b/lib/src/widget/asset_picker_viewer.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 import '../constants/enums.dart';
-import '../delegates/asset_picker_builder_delegate.dart';
+import '../constants/typedefs.dart';
 import '../delegates/asset_picker_viewer_builder_delegate.dart';
 import '../provider/asset_picker_provider.dart';
 import '../provider/asset_picker_viewer_provider.dart';

--- a/lib/wechat_assets_picker.dart
+++ b/lib/wechat_assets_picker.dart
@@ -5,6 +5,7 @@ export 'package:photo_manager/photo_manager.dart';
 export 'src/constants/config.dart';
 export 'src/constants/constants.dart';
 export 'src/constants/enums.dart';
+export 'src/constants/typedefs.dart';
 export 'src/delegates/asset_picker_builder_delegate.dart';
 export 'src/delegates/asset_picker_text_delegate.dart';
 export 'src/delegates/asset_picker_viewer_builder_delegate.dart';


### PR DESCRIPTION
Resolves #262.

## Breaking changes:
- `specialItemBuilder` has a different signature.
- `allowSpecialItemWhenEmpty` has been removed.

## Code migration

Before:
```dart
specialItemBuilder: (BuildContext context) {
  return someWidget;
}
```

After:
```dart
specialItemBuilder: (BuildContext context, AssetPathEntity? path, int length) {
  if (path?.isAll != true) {
    return null;
  }
  return someWidget;
}
```