### PR TITLE
Add support to filter lists with a custom function

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Fields in `AssetPickerConfig`:
 | loadingIndicatorBuilder | `IndicatorBuilder?`                  | Indicates the loading status for the builder.                             | `null`                      |
 | selectPredicate         | `AssetSelectPredicate`               | Predicate whether an asset can be selected or unselected.                 | `null`                      |
 | shouldRevertGrid        | `bool?`                              | Whether the assets grid should revert.                                    | `null`                      |
+| assetFilterFunction        | `AssetFilterFunction?`                              | A function by which to filter the assets list.                                    | `null`                      |
 
 ### Detailed usage
 

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -383,6 +383,41 @@ class PickMethod {
     );
   }
 
+  factory PickMethod.filtered(int maxAssetsCount) {
+    final List<String> mimeTypeWhitelist = <String>[
+      'image/jpg',
+      'image/jpeg',
+      'image/png',
+      'video/mp4',
+    ];
+
+    return PickMethod(
+      icon: '🎯',
+      name: 'Custom Filter Function',
+      description: 'Pick from a filtered list of assets with a function',
+      method: (BuildContext context, List<AssetEntity> assets) {
+        return AssetPicker.pickAssets(
+          context,
+          pickerConfig: AssetPickerConfig(
+            maxAssets: maxAssetsCount,
+            selectedAssets: assets,
+            requestType: RequestType.common,
+            assetFilterFunction: (List<dynamic> assets) async {
+              final List<AssetEntity> filteredAssets = <AssetEntity>[];
+              for (final AssetEntity asset in assets as List<AssetEntity>) {
+                final String? mimeType = await asset.mimeTypeAsync;
+                if (mimeTypeWhitelist.contains(mimeType)) {
+                  filteredAssets.add(asset);
+                }
+              }
+              return filteredAssets;
+            },
+          ),
+        );
+      },
+    );
+  }
+
   final String icon;
   final String name;
   final String description;

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -52,6 +52,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage>
       PickMethod.noPreview(maxAssetsCount),
       PickMethod.customizableTheme(maxAssetsCount),
       PickMethod.customFilterOptions(maxAssetsCount),
+      PickMethod.filtered(maxAssetsCount),
       PickMethod.preventGIFPicked(maxAssetsCount),
       PickMethod.keepScrollOffset(
         delegate: () => keepScrollDelegate!,

--- a/example/lib/pages/single_assets_page.dart
+++ b/example/lib/pages/single_assets_page.dart
@@ -37,6 +37,7 @@ class _SingleAssetPageState extends State<SingleAssetPage>
       PickMethod.threeItemsGrid(maxAssetsCount),
       PickMethod.prependItem(maxAssetsCount),
       PickMethod.customFilterOptions(maxAssetsCount),
+      PickMethod.filtered(maxAssetsCount),
       PickMethod.preventGIFPicked(maxAssetsCount),
       PickMethod.noPreview(maxAssetsCount),
       PickMethod.customizableTheme(maxAssetsCount),

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -33,6 +33,7 @@ class AssetPickerConfig {
     this.loadingIndicatorBuilder,
     this.selectPredicate,
     this.shouldRevertGrid,
+    this.assetFilterFunction,
   })  : assert(maxAssets >= 1, 'maxAssets must be greater than 1.'),
         assert(
           pickerTheme == null || themeColor == null,
@@ -173,4 +174,7 @@ class AssetPickerConfig {
   /// [Null] means judging by [isAppleOS].
   /// 使用 [Null] 即使用 [isAppleOS] 进行判断。
   final bool? shouldRevertGrid;
+
+  /// A function to filter the asset list on
+  final AssetFilterFunction? assetFilterFunction;
 }

--- a/lib/src/constants/typedefs.dart
+++ b/lib/src/constants/typedefs.dart
@@ -21,6 +21,12 @@ typedef AssetSelectPredicate<Asset> = FutureOr<bool> Function(
   bool isSelected,
 );
 
+/// {@template wechat_assets_picker.AssetFilterFunction}
+/// Function to filter the list of assets returned
+typedef AssetFilterFunction<Asset> = FutureOr<List<Asset>> Function(
+  List<Asset> assets,
+);
+
 /// {@template wechat_asset_picker.SpecialItemBuilder}
 /// Build the special item according the given path and assets length.
 /// 根据给定的目录和资源数量构建特殊 item

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 import '../constants/constants.dart';
+import '../constants/typedefs.dart';
 import '../delegates/sort_path_delegate.dart';
 import '../internal/singleton.dart';
 
@@ -235,6 +236,7 @@ class DefaultAssetPickerProvider
     int maxAssets = 9,
     int pageSize = 80,
     ThumbnailSize pathThumbnailSize = const ThumbnailSize.square(80),
+    this.assetFilterFunction,
   }) : super(
           maxAssets: maxAssets,
           pageSize: pageSize,
@@ -263,6 +265,10 @@ class DefaultAssetPickerProvider
   /// Will be merged into the base configuration.
   /// 将会与基础条件进行合并。
   final FilterOptionGroup? filterOptions;
+
+  /// Custom filter function before displaying the list
+  ///
+  final AssetFilterFunction? assetFilterFunction;
 
   @override
   Future<void> getPaths() async {
@@ -316,7 +322,12 @@ class DefaultAssetPickerProvider
       page: page,
       size: pageSize,
     );
-    _currentAssets = List<AssetEntity>.of(list);
+    if (assetFilterFunction != null) {
+      _currentAssets = await assetFilterFunction!(List<AssetEntity>.of(list))
+          as List<AssetEntity>;
+    } else {
+      _currentAssets = List<AssetEntity>.of(list);
+    }
     _hasAssetsToDisplay = currentAssets.isNotEmpty;
     notifyListeners();
   }
@@ -409,6 +420,7 @@ class DefaultAssetPickerProvider
       _currentPath = _pathsList.keys.elementAt(0);
       totalAssetsCount = currentPath!.assetCount;
       await getAssetsFromPath(0, currentPath!);
+      isAssetsEmpty = currentAssets.isEmpty;
     } else {
       isAssetsEmpty = true;
     }

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -45,6 +45,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
       requestType: pickerConfig.requestType,
       sortPathDelegate: pickerConfig.sortPathDelegate,
       filterOptions: pickerConfig.filterOptions,
+      assetFilterFunction: pickerConfig.assetFilterFunction,
     );
     final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
       key: Singleton.pickerKey,


### PR DESCRIPTION
A feature I was missing was to be able to filter the list of assets by mime type as we only support specific video file types. I could have created a custom builder and provider, but the simpler solution seemed to be to provide it within the `DefaultAssetPickerProvider`

There is the `selectPredicate` however that just means you can't select an item and there is no feedback to the user for why it couldn't be selected.

This PR changes the Picker config to take in a custom function which can be used to filter the output list to not show undesired assets in the first place. In the example I'm using the mime type, but any other function returning a bool would work.

The only thing I'm not certain about is that currently in the `AssetPickerConfig` the function is currently untyped/dynamic as it doesn't get the type from the `DefaultAssetPickerBuilderDelegate` at that level, so there was some casting involved. Maybe there is a better solution to that