### PR TITLE
Fix for Gradle plugin requires Java 11 to run. You are currently using Java 1.8.

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
This PR:

Adds the default Linux installation path for Java to the `gradle.properties` file.
This saves developers the tussle undergone in order to be able to run the example implementation of the `wechat_asset_picker`.
Precisely, it solves the error: 

> Gradle plugin requires Java 11 to run. You are currently using Java 1.8.
