### PR TITLE
🐛 Fix behaviors when unselecting all assets in the viewer

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1459,8 +1459,8 @@ class DefaultAssetPickerBuilderDelegate
           minWidth: p.isSelectedNotEmpty ? 48 : 20,
           height: appBarItemHeight,
           padding: const EdgeInsets.symmetric(horizontal: 12),
+          color: theme.colorScheme.secondary,
           disabledColor: theme.dividerColor,
-          color: p.isSelectedNotEmpty ? themeColor : theme.dividerColor,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(3),
           ),

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -790,48 +790,55 @@ class DefaultAssetPickerViewerBuilderDelegate
             'Viewer provider must not be null '
             'when the special type is not WeChat moment.',
           );
+          Future<void> onPressed() async {
+            if (isWeChatMoment && hasVideo) {
+              Navigator.of(context).pop(<AssetEntity>[currentAsset]);
+              return;
+            }
+            if (provider!.isSelectedNotEmpty) {
+              Navigator.of(context).pop(provider.currentlySelectedAssets);
+              return;
+            }
+            if (await onChangingSelected(context, currentAsset, false)) {
+              Navigator.of(context).pop(
+                selectedAssets ?? <AssetEntity>[currentAsset],
+              );
+            }
+          }
+
+          String buildText() {
+            if (isWeChatMoment && hasVideo) {
+              return textDelegate.confirm;
+            }
+            if (provider!.isSelectedNotEmpty) {
+              return '${textDelegate.confirm}'
+                  ' (${provider.currentlySelectedAssets.length}'
+                  '/'
+                  '${selectorProvider!.maxAssets})';
+            }
+            return textDelegate.confirm;
+          }
+
+          final bool isButtonEnabled = provider == null ||
+              provider.currentlySelectedAssets.isNotEmpty ||
+              previewAssets.isEmpty ||
+              selectedNotifier.value == 0;
           return MaterialButton(
-            minWidth: () {
-              if (isWeChatMoment && hasVideo) {
-                return 48.0;
-              }
-              return provider!.isSelectedNotEmpty ? 48.0 : 20.0;
-            }(),
-            height: 32.0,
-            padding: const EdgeInsets.symmetric(horizontal: 12.0),
+            minWidth:
+                (isWeChatMoment && hasVideo) || provider!.isSelectedNotEmpty
+                    ? 48
+                    : 20,
+            height: 32,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
             color: themeData.colorScheme.secondary,
+            disabledColor: themeData.dividerColor,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(3.0),
+              borderRadius: BorderRadius.circular(3),
             ),
-            onPressed: () async {
-              if (isWeChatMoment && hasVideo) {
-                Navigator.of(context).pop(<AssetEntity>[currentAsset]);
-                return;
-              }
-              if (provider!.isSelectedNotEmpty) {
-                Navigator.of(context).pop(provider.currentlySelectedAssets);
-                return;
-              }
-              if (await onChangingSelected(context, currentAsset, false)) {
-                Navigator.of(context).pop(
-                  selectedAssets ?? <AssetEntity>[currentAsset],
-                );
-              }
-            },
+            onPressed: isButtonEnabled ? onPressed : null,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
             child: ScaleText(
-              () {
-                if (isWeChatMoment && hasVideo) {
-                  return textDelegate.confirm;
-                }
-                if (provider!.isSelectedNotEmpty) {
-                  return '${textDelegate.confirm}'
-                      ' (${provider.currentlySelectedAssets.length}'
-                      '/'
-                      '${selectorProvider!.maxAssets})';
-                }
-                return textDelegate.confirm;
-              }(),
+              buildText(),
               style: TextStyle(
                 color: themeData.textTheme.bodyText1?.color,
                 fontSize: 17,


### PR DESCRIPTION
Fix #328, two behaviors are now aligned with WeChat, more specifically after selected assets:
- Clicking the "Preview" button and unselecting all assets, the "Confirm" button will be disabled.
- Clicking the asset's preview and unselecting all assets, the "Confirm" button will remain enabled but with no counter (X/9), and clicking the button will return the viewing asset.

See the screen record for more details:
https://user-images.githubusercontent.com/15884415/172569846-2fb84129-daa5-4b3e-aa5d-7d61458ef5cd.mp4

