### PR TITLE
✨ Introduce `PathWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 8.0.0-dev.1
+
+To know more about breaking changes, see [Migration Guide][].
+
+### Improvements
+
+- Introduce `PathWrapper` to improve the overall loading speed. (#338)
+
 ## 7.3.2
 
 ### Improvements

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,7 +29,8 @@ analyzer:
 
 linter:
   rules:
-    # This list is derived from the list of all available lints located at
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
     - always_declare_return_types
     - always_put_control_body_on_new_line
@@ -40,34 +41,32 @@ linter:
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_bool_literals_in_conditional_expressions
-    # - avoid_catches_without_on_clauses # blocked on https://github.com/dart-lang/linter/issues/3023
-    # - avoid_catching_errors # blocked on https://github.com/dart-lang/linter/issues/3023
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
     - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
     - avoid_dynamic_calls
     - avoid_empty_else
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
-    # - avoid_final_parameters # incompatible with prefer_final_parameters
     - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
+    # - avoid_implementing_value_types # not yet tested
     - avoid_init_to_null
-    - avoid_js_rounded_ints
-    # - avoid_multiple_declarations_per_line # seems to be a stylistic choice we don't subscribe to
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators
-    # - avoid_positional_boolean_parameters # would have been nice to enable this but by now there's too many places that break it
-    - avoid_print
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_print # not yet tested
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
     - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    # - avoid_returning_null # still violated by some pre-nnbd code that we haven't yet migrated
-    - avoid_returning_null_for_future
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_null_for_future # not yet tested
     - avoid_returning_null_for_void
-    # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
-    - avoid_setters_without_getters
+    # - avoid_returning_this # there are plenty of valid reasons to return this
+    # - avoid_setters_without_getters # not yet tested
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
@@ -77,28 +76,24 @@ linter:
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
-    # - avoid_web_libraries_in_flutter # we use web libraries in web-specific code, and our tests prevent us from using them elsewhere
+    # - avoid_web_libraries_in_flutter # not yet tested
     - await_only_futures
     - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
-    # - cascade_invocations # doesn't match the typical style of this repo
-    - cast_nullable_to_non_nullable
+    # - cascade_invocations # not yet tested
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
-    # - conditional_uri_does_not_exist # not yet tested
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     # - curly_braces_in_flow_control_structures # not required by flutter style
-    - depend_on_referenced_packages
     - deprecated_consistency
-    # - diagnostic_describe_all_properties # enabled only at the framework level (packages/flutter/lib)
+    # - diagnostic_describe_all_properties # not yet tested
     - directives_ordering
-    # - do_not_use_environment # there are appropriate times to use the environment, especially in our tests and build logic
+    # - do_not_use_environment # we do this commonly
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - eol_at_end_of_file
     - exhaustive_cases
     - file_names
     - flutter_style_todos
@@ -110,25 +105,22 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
-    - library_private_types_in_public_api
     # - lines_longer_than_80_chars # not required by flutter style
     - list_remove_unrelated_type
-    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/linter/issues/453
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
-    - no_default_cases
+    # - no_default_cases # too many false positives
     - no_duplicate_case_values
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/
-    - non_constant_identifier_names
     - noop_primitive_operations
+    - non_constant_identifier_names
     - null_check_on_nullable_type_parameter
     - null_closures
     # - omit_local_variable_types # opposite of always_specify_types
     # - one_member_abstracts # too many false positives
-    - only_throw_errors # this does get disabled in a few places where we have legacy code that uses strings et al
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     - overridden_fields
     - package_api_docs
     - package_names
@@ -151,7 +143,6 @@ linter:
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
-    # - prefer_final_parameters # we should enable this one day when it can be auto-fixed (https://github.com/dart-lang/linter/issues/3104), see also parameter_assignments
     - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
     - prefer_function_declarations_over_variables
@@ -166,10 +157,9 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
-    # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     - prefer_null_aware_operators
-    - prefer_relative_imports
+    # - prefer_relative_imports # incompatible with sub-package imports
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables
@@ -177,12 +167,10 @@ linter:
     - provide_deprecation_message
     # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
     - recursive_getters
-    # - require_trailing_commas # blocked on https://github.com/dart-lang/sdk/issues/47441
-    - secure_pubspec_urls
+    - require_trailing_commas
     - sized_box_for_whitespace
-    # - sized_box_shrink_expand # not yet tested
     - slash_for_doc_comments
-    - sort_child_properties_last
+    # - sort_child_properties_last # not yet tested
     - sort_constructors_first
     # - sort_pub_dependencies # prevents separating pinned transitive dependencies
     - sort_unnamed_constructors_first
@@ -191,15 +179,13 @@ linter:
     - tighten_type_of_initializing_formals
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # too many false positives, especially with the way AnimationController works
+    # - unawaited_futures # too many false positives
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
-    - unnecessary_constructor_name
     # - unnecessary_final # conflicts with prefer_final_locals
     - unnecessary_getters_setters
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
-    - unnecessary_late
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_checks
@@ -207,29 +193,24 @@ linter:
     - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
-    # - unnecessary_raw_strings # what's "necessary" is a matter of opinion; consistency across strings can help readability more than this lint
+    # - unnecessary_raw_strings # not yet tested
     - unnecessary_statements
     - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
     - unrelated_type_equality_checks
-    - unsafe_html
-    # - use_build_context_synchronously
-    # - use_colored_box # not yet tested
-    # - use_decorated_box # not yet tested
-    # - use_enums # not yet tested
+    # - unsafe_html # not yet tested
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
+    # - use_if_null_to_convert_nulls_to_bools # not yet tested
     - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors
     - use_late_for_private_fields_and_variables
     - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible
-    - use_setters_to_change_properties
+    # - use_setters_to_change_properties # not yet tested
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
-    - use_super_parameters
     - use_test_throws_matchers
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
     - valid_regexps

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -164,8 +164,9 @@ class PickMethod {
                     final DefaultAssetPickerBuilderDelegate builder =
                         picker.builder as DefaultAssetPickerBuilderDelegate;
                     final DefaultAssetPickerProvider p = builder.provider;
-                    p.currentPath =
-                        await p.currentPath!.obtainForNewProperties();
+                    p.currentPath = PathWrapper<AssetPathEntity>(
+                      path: await p.currentPath!.path.obtainForNewProperties(),
+                    );
                     await p.switchPath(p.currentPath);
                     p.selectAsset(result);
                   },

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -164,12 +164,13 @@ class PickMethod {
                     final DefaultAssetPickerBuilderDelegate builder =
                         picker.builder as DefaultAssetPickerBuilderDelegate;
                     final DefaultAssetPickerProvider p = builder.provider;
-                    p
-                      ..currentAssets.insert(0, result)
-                      ..currentPath = p.currentPath!.copyWith(
-                        assetCount: p.currentPath!.assetCount! + 1,
-                      )
-                      ..selectAsset(result);
+                    await p.switchPath(
+                      PathWrapper<AssetPathEntity>(
+                        path:
+                            await p.currentPath!.path.obtainForNewProperties(),
+                      ),
+                    );
+                    p.selectAsset(result);
                   },
                   child: const Center(
                     child: Icon(Icons.camera_enhance, size: 42.0),

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -164,11 +164,12 @@ class PickMethod {
                     final DefaultAssetPickerBuilderDelegate builder =
                         picker.builder as DefaultAssetPickerBuilderDelegate;
                     final DefaultAssetPickerProvider p = builder.provider;
-                    p.currentPath = PathWrapper<AssetPathEntity>(
-                      path: await p.currentPath!.path.obtainForNewProperties(),
-                    );
-                    await p.switchPath(p.currentPath);
-                    p.selectAsset(result);
+                    p
+                      ..currentAssets.insert(0, result)
+                      ..currentPath = p.currentPath!.copyWith(
+                        assetCount: p.currentPath!.assetCount! + 1,
+                      )
+                      ..selectAsset(result);
                   },
                   child: const Center(
                     child: Icon(Icons.camera_enhance, size: 42.0),

--- a/example/lib/customs/pickers/multi_tabs_assets_picker.dart
+++ b/example/lib/customs/pickers/multi_tabs_assets_picker.dart
@@ -307,17 +307,18 @@ class MultiTabAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
               borderRadius: BorderRadius.circular(999),
               color: theme.dividerColor,
             ),
-            child: Selector<DefaultAssetPickerProvider, AssetPathEntity?>(
+            child: Selector<DefaultAssetPickerProvider,
+                PathWrapper<AssetPathEntity>?>(
               selector: (_, DefaultAssetPickerProvider p) => p.currentPath,
-              builder: (_, AssetPathEntity? p, Widget? w) => Row(
+              builder: (_, PathWrapper<AssetPathEntity>? p, Widget? w) => Row(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   if (p != null)
                     Flexible(
                       child: Text(
-                        isPermissionLimited && p.isAll
+                        isPermissionLimited && p.path.isAll
                             ? textDelegate.accessiblePathName
-                            : p.name,
+                            : p.path.name,
                         style: const TextStyle(
                           fontSize: 17,
                           fontWeight: FontWeight.normal,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_assets_picker_demo
 description: The demo project for the wechat_assets_picker package.
-version: 7.3.2+19
+version: 8.0.0+20
 publish_to: none
 
 environment:

--- a/guides/migration_guide.md
+++ b/guides/migration_guide.md
@@ -28,19 +28,19 @@ a new concept `PathWrapper` to hold metadata together, but initialize fields sep
 
 #### `AssetPickerProvider`
 
-- `AssetPickerProvider.currentPath` has been changed from `Path?` to `PathWrapper<Path>?`.
-- `AssetPickerProvider.pathsList` has been removed, and added `AssetPickerProvider.paths`.
-- `AssetPickerProvider.totalAssetsCount` is now nullable to indicates initialization.
-- `AssetPickerProvider.getThumbnailFromPath`, `AssetPickerProvider.switchPath`
-  have different signature from `Path` to `PathWrapper<Path>`.
+- `currentPath` has been changed from `Path?` to `PathWrapper<Path>?`.
+- `pathsList` has been removed, and added `AssetPickerProvider.paths`.
+- `totalAssetsCount` is now nullable to indicates initialization.
+- `getThumbnailFromPath` and `switchPath` have different signature from `Path` to `PathWrapper<Path>`.
 
 #### `AssetPickerBuilderDelegate`
 
-`AssetPickerBuilderDelegate.pathEntityWidget` has different signature from `Path` to `PathWrapper<Path>`.
+- `pathEntityWidget` has different signature from `Path` to `PathWrapper<Path>`,
+  and the `isAudio` argument has been removed.
 
 #### `SortPathDelegate`
 
-`SortPathDelegate.sort` has a different signature, which needs `PathWrapper`s to sort. More specifically:
+`sort` has a different signature, which needs `PathWrapper`s to sort. More specifically:
 
 Before:
 

--- a/guides/migration_guide.md
+++ b/guides/migration_guide.md
@@ -8,9 +8,51 @@ This document gathered all breaking changes and migrations requirement between m
 
 ## Major versions
 
+- [8.0.0](#8.0.0)
 - [7.0.0](#7.0.0)
 - [6.0.0](#6.0.0)
 - [5.0.0](#5.0.0)
+
+## 8.0.0
+
+### Summary
+
+_If you didn't extend `AssetPickerProvider`, `AssetPickerBuilderDelegate` or `SortPathDelegate`, you can stop reading._
+
+`AssetPathEntity.assetCountAsync` was introduced in
+[fluttercandies/flutter_photo_manager#784](https://github.com/fluttercandies/flutter_photo_manager/pull/784)
+to improve the loading performance during paths obtain. By migrating the asynchronous getter, we need to introduce
+a new concept `PathWrapper` to hold metadata together, but initialize fields separately.
+
+### Details
+
+#### `AssetPickerProvider`
+
+- `AssetPickerProvider.currentPath` has been changed from `Path?` to `PathWrapper<Path>?`.
+- `AssetPickerProvider.pathsList` has been removed, and added `AssetPickerProvider.paths`.
+- `AssetPickerProvider.totalAssetsCount` is now nullable to indicates initialization.
+- `AssetPickerProvider.getThumbnailFromPath`, `AssetPickerProvider.switchPath`
+  have different signature from `Path` to `PathWrapper<Path>`.
+
+#### `AssetPickerBuilderDelegate`
+
+`AssetPickerBuilderDelegate.pathEntityWidget` has different signature from `Path` to `PathWrapper<Path>`.
+
+#### `SortPathDelegate`
+
+`SortPathDelegate.sort` has a different signature, which needs `PathWrapper`s to sort. More specifically:
+
+Before:
+
+```dart
+void sort(List<Path> list) {}
+```
+
+After:
+
+```dart
+void soft(List<PathWrapper<Path>> list) {}
+```
 
 ## 7.0.0
 

--- a/lib/src/delegates/sort_path_delegate.dart
+++ b/lib/src/delegates/sort_path_delegate.dart
@@ -4,6 +4,8 @@
 
 import 'package:photo_manager/photo_manager.dart';
 
+import '../models/path_wrapper.dart';
+
 /// Delegate to sort asset path entities.
 /// 用于资源路径排序的实现
 ///
@@ -13,7 +15,7 @@ import 'package:photo_manager/photo_manager.dart';
 abstract class SortPathDelegate<Path> {
   const SortPathDelegate();
 
-  void sort(List<Path> list);
+  void sort(List<PathWrapper<Path>> list);
 
   static const SortPathDelegate<AssetPathEntity> common =
       CommonSortPathDelegate();
@@ -29,39 +31,45 @@ class CommonSortPathDelegate extends SortPathDelegate<AssetPathEntity> {
   const CommonSortPathDelegate();
 
   @override
-  void sort(List<AssetPathEntity> list) {
-    if (list.any((AssetPathEntity e) => e.lastModified != null)) {
-      list.sort((AssetPathEntity path1, AssetPathEntity path2) {
-        if (path1.lastModified == null || path2.lastModified == null) {
-          return 0;
+  void sort(List<PathWrapper<AssetPathEntity>> list) {
+    if (list.any(
+      (PathWrapper<AssetPathEntity> e) => e.path.lastModified != null,
+    )) {
+      list.sort(
+        (PathWrapper<AssetPathEntity> a, PathWrapper<AssetPathEntity> b) {
+          if (a.path.lastModified == null || b.path.lastModified == null) {
+            return 0;
+          }
+          if (b.path.lastModified!.isAfter(a.path.lastModified!)) {
+            return 1;
+          }
+          return -1;
+        },
+      );
+    }
+    list.sort(
+      (PathWrapper<AssetPathEntity> a, PathWrapper<AssetPathEntity> b) {
+        if (a.path.isAll) {
+          return -1;
         }
-        if (path2.lastModified!.isAfter(path1.lastModified!)) {
+        if (a.path.isAll) {
           return 1;
         }
-        return -1;
-      });
-    }
-    list.sort((AssetPathEntity path1, AssetPathEntity path2) {
-      if (path1.isAll) {
-        return -1;
-      }
-      if (path2.isAll) {
-        return 1;
-      }
-      if (_isCamera(path1)) {
-        return -1;
-      }
-      if (_isCamera(path2)) {
-        return 1;
-      }
-      if (_isScreenShot(path1)) {
-        return -1;
-      }
-      if (_isScreenShot(path2)) {
-        return 1;
-      }
-      return 0;
-    });
+        if (_isCamera(a.path)) {
+          return -1;
+        }
+        if (_isCamera(b.path)) {
+          return 1;
+        }
+        if (_isScreenShot(a.path)) {
+          return -1;
+        }
+        if (_isScreenShot(b.path)) {
+          return 1;
+        }
+        return 0;
+      },
+    );
   }
 
   int otherSort(AssetPathEntity path1, AssetPathEntity path2) {

--- a/lib/src/models/path_wrapper.dart
+++ b/lib/src/models/path_wrapper.dart
@@ -73,4 +73,13 @@ class PathWrapper<Path> {
   @override
   int get hashCode =>
       path.hashCode ^ assetCount.hashCode ^ thumbnailData.hashCode;
+
+  @override
+  String toString() {
+    return '$runtimeType('
+        'path: $path, '
+        'assetCount: $assetCount, '
+        'thumbnailData: ${thumbnailData?.runtimeType}'
+        ')';
+  }
 }

--- a/lib/src/models/path_wrapper.dart
+++ b/lib/src/models/path_wrapper.dart
@@ -1,0 +1,58 @@
+//
+// [Author] Alex (https://github.com/AlexV525)
+// [Date] 2022/6/30 22:55
+//
+
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+
+/// A wrapper that holds [Path] with it's nullable (late initialize) fields.
+///
+/// The asset count usually backed by [AssetPathEntity.assetCountAsync],
+/// and the thumbnail usually backed by [AssetEntity.thumbnailData].
+/// These methods are asynchronous and called separately for better performance.
+/// After calls, use [copyWith] to update paths to avoid unnecessary waits.
+///
+/// [Path] is typically an [AssetPathEntity].
+@immutable
+class PathWrapper<Path> {
+  const PathWrapper({
+    required this.path,
+    this.assetCount,
+    this.thumbnailData,
+  });
+
+  final Path path;
+  final int? assetCount;
+  final Uint8List? thumbnailData;
+
+  PathWrapper<Path> copyWith({
+    int? assetCount,
+    Uint8List? thumbnailData,
+  }) {
+    return PathWrapper<Path>(
+      path: path,
+      assetCount: assetCount ?? this.assetCount,
+      thumbnailData: thumbnailData ?? this.thumbnailData,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is PathWrapper<Path> &&
+        other.path == path &&
+        other.assetCount == assetCount &&
+        other.thumbnailData == thumbnailData;
+  }
+
+  @override
+  int get hashCode =>
+      path.hashCode ^ assetCount.hashCode ^ thumbnailData.hashCode;
+}

--- a/lib/src/models/path_wrapper.dart
+++ b/lib/src/models/path_wrapper.dart
@@ -13,8 +13,6 @@ import 'package:flutter/foundation.dart';
 /// and the thumbnail usually backed by [AssetEntity.thumbnailData].
 /// These methods are asynchronous and called separately for better performance.
 /// After calls, use [copyWith] to update paths to avoid unnecessary waits.
-///
-/// [Path] is typically an [AssetPathEntity].
 @immutable
 class PathWrapper<Path> {
   const PathWrapper({
@@ -23,10 +21,31 @@ class PathWrapper<Path> {
     this.thumbnailData,
   });
 
+  /// Typically an [AssetPathEntity].
   final Path path;
+
+  /// The total asset count of the [path].
+  ///
+  /// Nullability represents whether it's initialized.
+  ///
+  /// See also:
+  ///  * [AssetPathEntity.assetCountAsync] API document:
+  ///    https://pub.dev/documentation/photo_manager/latest/photo_manager/AssetPathEntity/assetCountAsync.html
   final int? assetCount;
+
+  /// The thumbnail (first asset) data of the [path].
+  ///
+  /// Nullability represents whether it's initialized.
+  ///
+  /// See also:
+  ///  * [AssetEntity.thumbnailData] API document:
+  ///    https://pub.dev/documentation/photo_manager/latest/photo_manager/AssetEntity/thumbnailData.html
   final Uint8List? thumbnailData;
 
+  /// Creates a modified copy of the object.
+  ///
+  /// Explicitly specified fields get the specified value, all other fields get
+  /// the same value of the current object.
   PathWrapper<Path> copyWith({
     int? assetCount,
     Uint8List? thumbnailData,

--- a/lib/src/models/path_wrapper.dart
+++ b/lib/src/models/path_wrapper.dart
@@ -1,7 +1,6 @@
-//
-// [Author] Alex (https://github.com/AlexV525)
-// [Date] 2022/6/30 22:55
-//
+// Copyright 2019 The FlutterCandies author. All rights reserved.
+// Use of this source code is governed by an Apache license that can be found
+// in the LICENSE file.
 
 import 'dart:typed_data';
 

--- a/lib/wechat_assets_picker.dart
+++ b/lib/wechat_assets_picker.dart
@@ -10,13 +10,18 @@ export 'src/constants/config.dart';
 export 'src/constants/constants.dart';
 export 'src/constants/enums.dart';
 export 'src/constants/typedefs.dart';
+
 export 'src/delegates/asset_picker_builder_delegate.dart';
 export 'src/delegates/asset_picker_delegate.dart';
 export 'src/delegates/asset_picker_text_delegate.dart';
 export 'src/delegates/asset_picker_viewer_builder_delegate.dart';
 export 'src/delegates/sort_path_delegate.dart';
+
+export 'src/models/path_wrapper.dart';
+
 export 'src/provider/asset_picker_provider.dart';
 export 'src/provider/asset_picker_viewer_provider.dart';
+
 export 'src/widget/asset_picker.dart';
 export 'src/widget/asset_picker_app_bar.dart';
 export 'src/widget/asset_picker_page_route.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   extended_image: ^6.2.0
-  photo_manager: ^2.1.0+1
+  photo_manager: ^2.2.0-dev.1
   provider: ^6.0.2
   video_player: ^2.4.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_assets_picker
 description: An audio/video/image picker in pure Dart which is the same with WeChat, support multi picking.
-version: 7.3.2
+version: 8.0.0-dev.1
 homepage: https://github.com/fluttercandies/flutter_wechat_assets_picker
 
 environment:

--- a/test/delegates/builder_delegate_test.dart
+++ b/test/delegates/builder_delegate_test.dart
@@ -52,7 +52,7 @@ void main() {
 class TestPhotoManagerPlugin extends PhotoManagerPlugin {
   @override
   Future<PermissionState> requestPermissionExtend(
-    PermisstionRequestOption requestOption,
+    PermissionRequestOption requestOption,
   ) {
     return SynchronousFuture<PermissionState>(PermissionState.authorized);
   }
@@ -90,7 +90,7 @@ class TestAssetPickerDelegate extends AssetPickerDelegate {
       ..currentAssets = <AssetEntity>[
         const AssetEntity(id: 'test', typeInt: 0, width: 0, height: 0),
       ]
-      ..currentPath = pathEntity
+      ..currentPath = PathWrapper<AssetPathEntity>(path: pathEntity)
       ..hasAssetsToDisplay = true
       ..setPathThumbnail(pathEntity, null);
     final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(

--- a/test/delegates/builder_delegate_test.dart
+++ b/test/delegates/builder_delegate_test.dart
@@ -45,7 +45,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byIcon(Icons.keyboard_arrow_down));
     await tester.pumpAndSettle();
-    expect(find.text('testPathNameBuilder'), findsNWidgets(2));
+    expect(find.text('testPathNameBuilder'), findsOneWidget);
   });
 }
 
@@ -90,9 +90,12 @@ class TestAssetPickerDelegate extends AssetPickerDelegate {
       ..currentAssets = <AssetEntity>[
         const AssetEntity(id: 'test', typeInt: 0, width: 0, height: 0),
       ]
-      ..currentPath = PathWrapper<AssetPathEntity>(path: pathEntity)
+      ..currentPath = PathWrapper<AssetPathEntity>(
+        path: pathEntity,
+        assetCount: 1,
+      )
       ..hasAssetsToDisplay = true
-      ..setPathThumbnail(pathEntity, null);
+      ..totalAssetsCount = 1;
     final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
       builder: DefaultAssetPickerBuilderDelegate(
         provider: provider,


### PR DESCRIPTION
`AssetPathEntity.assetCountAsync` was provided since https://github.com/fluttercandies/flutter_photo_manager/pull/784 of photo_manager.

By migrating the asynchronous getter, we need to introduce a wrapper `PathWrapper` to hold asset count and thumbnail data in the same place, but can be in different time spaces.

This PR brings breaking changes, as recorded:
- `AssetPickerProvider.currentPath` has been changed from `Path?` to `PathWrapper<Path>?`.
- `AssetPickerProvider.pathsList` has been removed, and added `AssetPickerProvider.paths`.
- `AssetPickerProvider.totalAssetsCount` is now nullable.
- `AssetPickerProvider.getThumbnailFromPath` and `AssetPickerProvider.switchPath` have different signature from `Path` to `PathWrapper<Path>`.
- `AssetPickerBuilderDelegate.pathEntityWidget` has different signature from `Path` to `PathWrapper<Path>`, and the `isAudio` argument has been removed.
- `SortPathDelegate.sort` has a different signature, which needs `PathWrapper`s to sort.