### PR TITLE
Fix iOS button enabled for no preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 8.1.4
+
+### Fixes
+
+- Fix conditions with the confirm button on iOS. (#376)
+
 ## 8.1.3
 
 ### Improvements

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_assets_picker_demo
 description: The demo project for the wechat_assets_picker package.
-version: 8.1.3+28
+version: 8.1.4+29
 publish_to: none
 
 environment:

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -952,7 +952,7 @@ class DefaultAssetPickerBuilderDelegate
             child: Stack(
               children: <Widget>[
                 Positioned.fill(child: assetsGridBuilder(context)),
-                if (!isSingleAssetMode || isAppleOS)
+                if (!isSingleAssetMode || isPreviewEnabled)
                   Positioned.fill(
                     top: null,
                     child: bottomActionBar(context),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   An audio/video/image picker in pure Dart which is the same with WeChat,
   support multi picking, custom item and delegates override.
 repository: https://github.com/fluttercandies/flutter_wechat_assets_picker
-version: 8.1.3
+version: 8.1.4
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
I have updated the behavior where the asset picker for iOS would still show the confirm button in the bottom app bar even if `isSingleAssetMode == true` and `isPreviewEnabled == false`.

I assume this to be a bug as:

1. Android is behaving different (as expected)
2. Inside `appleOSLayout` I assume the `isAppleOS` check is unneeded

If suitable, please let me know whether this needs a changelog entry and which formatting requirements this has.

closes #377