### PR TITLE
New custom insta delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 8.3.1
+
+### New features
+
+- Add `didUpdateViewer` and `initAnimations` in the `AssetPickerViewerBuilderDelegate`. (#403)
+- Add insta_assets_picker as an custom delegate example. (#403)
+
 ## 8.3.0
 
 ### New features

--- a/example/lib/customs/custom_picker_page.dart
+++ b/example/lib/customs/custom_picker_page.dart
@@ -3,6 +3,7 @@
 // in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:wechat_assets_picker_demo/customs/pickers/insta_asset_picker.dart';
 
 import '../constants/custom_pick_method.dart';
 import 'pickers/directory_file_asset_picker.dart';
@@ -49,6 +50,15 @@ class _CustomPickerPageState extends State<CustomPickersPage>
             'assets for the picking at the same time.',
         method: (BuildContext context) => Navigator.of(context).push<void>(
           MaterialPageRoute<void>(builder: (_) => const MultiTabAssetPicker()),
+        ),
+      ),
+      CustomPickMethod(
+        icon: '📷',
+        name: 'Instagram layout picker',
+        description: 'The picker reproduces instagram layout with preview and '
+            'scroll animations.',
+        method: (BuildContext context) => Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(builder: (_) => const InstaAssetPicker()),
         ),
       ),
     ];

--- a/example/lib/customs/custom_picker_page.dart
+++ b/example/lib/customs/custom_picker_page.dart
@@ -3,10 +3,10 @@
 // in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:wechat_assets_picker_demo/customs/pickers/insta_asset_picker.dart';
 
 import '../constants/custom_pick_method.dart';
 import 'pickers/directory_file_asset_picker.dart';
+import 'pickers/insta_asset_picker.dart';
 import 'pickers/multi_tabs_assets_picker.dart';
 
 class CustomPickersPage extends StatefulWidget {
@@ -55,8 +55,8 @@ class _CustomPickerPageState extends State<CustomPickersPage>
       CustomPickMethod(
         icon: '📷',
         name: 'Instagram layout picker',
-        description: 'The picker reproduces instagram layout with preview and '
-            'scroll animations.',
+        description: 'The picker reproduces Instagram layout with preview and '
+            "scroll animations. It's also published as the package insta_assets_picker.",
         method: (BuildContext context) => Navigator.of(context).push<void>(
           MaterialPageRoute<void>(builder: (_) => const InstaAssetPicker()),
         ),

--- a/example/lib/customs/pickers/insta_asset_picker.dart
+++ b/example/lib/customs/pickers/insta_asset_picker.dart
@@ -2,15 +2,18 @@
 // Use of this source code is governed by an Apache license that can be found
 // in the LICENSE file.
 
+/// Author: Maël (https://github.com/LeGoffMael)
+///
+/// See the package https://github.com/LeGoffMael/insta_assets_picker
+/// for the complete implementations.
+
 import 'dart:math';
 
+import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
-
-// ignore: directives_ordering
-import 'package:extended_image/extended_image.dart';
 
 /// The reduced height of the viewer
 const double _kReducedViewerHeight = kToolbarHeight;

--- a/example/lib/customs/pickers/insta_asset_picker.dart
+++ b/example/lib/customs/pickers/insta_asset_picker.dart
@@ -1,0 +1,730 @@
+// Copyright 2019 The FlutterCandies author. All rights reserved.
+// Use of this source code is governed by an Apache license that can be found
+// in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
+import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+/// The reduced height of the viewer
+const double _kReducedViewerHeight = kToolbarHeight;
+
+/// The position of the viewer when extended
+const double _kExtendedViewerPosition = 0.0;
+const double _kIndicatorSize = 20.0;
+const double _kPathSelectorRowHeight = 50.0;
+
+const Color _themeColor = Color(0xffe1306c);
+
+class InstaAssetPicker extends StatefulWidget {
+  const InstaAssetPicker({super.key});
+
+  @override
+  State<InstaAssetPicker> createState() => _InstaAssetPickerState();
+}
+
+class _InstaAssetPickerState extends State<InstaAssetPicker> {
+  final int maxAssets = 10;
+  late final ThemeData theme = AssetPicker.themeData(_themeColor);
+  List<AssetEntity> entities = <AssetEntity>[];
+
+  bool isDisplayingDetail = true;
+
+  Future<void> callPicker(BuildContext context) async {
+    final PermissionState ps = await AssetPicker.permissionCheck();
+
+    final DefaultAssetPickerProvider provider = DefaultAssetPickerProvider(
+      selectedAssets: entities,
+      maxAssets: maxAssets,
+    );
+
+    final InstaAssetPickerBuilder builder = InstaAssetPickerBuilder(
+      provider: provider,
+      initialPermission: ps,
+      pickerTheme: theme,
+      locale: Localizations.maybeLocaleOf(context),
+    );
+    final List<AssetEntity>? result = await AssetPicker.pickAssetsWithDelegate(
+      context,
+      delegate: builder,
+    );
+
+    if (result != null) {
+      entities = result;
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  Widget get selectedAssetsWidget {
+    return AnimatedContainer(
+      duration: kThemeChangeDuration,
+      curve: Curves.easeInOut,
+      height: entities.isNotEmpty
+          ? isDisplayingDetail
+              ? 120.0
+              : 80.0
+          : 40.0,
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 20.0,
+            child: GestureDetector(
+              onTap: () {
+                if (entities.isNotEmpty) {
+                  setState(() {
+                    isDisplayingDetail = !isDisplayingDetail;
+                  });
+                }
+              },
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Text('Selected Assets'),
+                  Container(
+                    margin: const EdgeInsets.symmetric(
+                      horizontal: 10.0,
+                    ),
+                    padding: const EdgeInsets.all(4.0),
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.grey,
+                    ),
+                    child: Text(
+                      '${entities.length}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        height: 1.0,
+                      ),
+                    ),
+                  ),
+                  if (entities.isNotEmpty)
+                    Icon(
+                      isDisplayingDetail
+                          ? Icons.arrow_downward
+                          : Icons.arrow_upward,
+                      size: 18.0,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          selectedAssetsListView,
+        ],
+      ),
+    );
+  }
+
+  Widget get selectedAssetsListView {
+    return Expanded(
+      child: ListView.builder(
+        physics: const BouncingScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        scrollDirection: Axis.horizontal,
+        itemCount: entities.length,
+        itemBuilder: (BuildContext _, int index) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 8.0,
+              vertical: 16.0,
+            ),
+            child: AspectRatio(
+              aspectRatio: 1.0,
+              child: Stack(
+                children: <Widget>[
+                  Positioned.fill(child: _selectedAssetWidget(index)),
+                  AnimatedPositionedDirectional(
+                    duration: kThemeAnimationDuration,
+                    top: isDisplayingDetail ? 6.0 : -30.0,
+                    end: isDisplayingDetail ? 6.0 : -30.0,
+                    child: _selectedAssetDeleteButton(index),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _selectedAssetWidget(int index) {
+    final AssetEntity asset = entities.elementAt(index);
+
+    Future<void> _onTap() async {
+      final List<AssetEntity>? result = await AssetPickerViewer.pushToViewer(
+        context,
+        currentIndex: index,
+        previewAssets: entities,
+        selectedAssets: entities,
+        themeData: theme,
+        maxAssets: maxAssets,
+      );
+      if (result != null) {
+        entities = result;
+        if (mounted) {
+          setState(() {});
+        }
+      }
+    }
+
+    return GestureDetector(
+      onTap: isDisplayingDetail ? _onTap : null,
+      child: RepaintBoundary(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8.0),
+          child: _assetWidgetBuilder(asset),
+        ),
+      ),
+    );
+  }
+
+  Widget _assetWidgetBuilder(AssetEntity asset) {
+    return Image(image: AssetEntityImageProvider(asset), fit: BoxFit.cover);
+  }
+
+  Widget _selectedAssetDeleteButton(int index) {
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          entities.removeAt(index);
+          if (entities.isEmpty) {
+            isDisplayingDetail = false;
+          }
+        });
+      },
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(4.0),
+          color: theme.canvasColor.withOpacity(0.5),
+        ),
+        child: Icon(
+          Icons.close,
+          color: theme.iconTheme.color,
+          size: 18.0,
+        ),
+      ),
+    );
+  }
+
+  Widget paddingText(String text) {
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: SelectableText(text),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Instagram picker')),
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(fontSize: 18),
+              textAlign: TextAlign.center,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  paddingText(
+                    'The picker reproduces instagram layout with preview and '
+                    'scroll animations.',
+                  ),
+                  TextButton(
+                    onPressed: () => callPicker(context),
+                    child: const Text(
+                      '🎁 Call the Picker',
+                      style: TextStyle(fontSize: 22),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          selectedAssetsWidget,
+        ],
+      ),
+    );
+  }
+}
+
+class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
+  InstaAssetPickerBuilder({
+    required super.provider,
+    required super.initialPermission,
+    super.gridCount = 4,
+    super.pickerTheme,
+    super.textDelegate,
+    super.locale,
+  }) : super(
+          shouldRevertGrid: false,
+          specialItemPosition: SpecialItemPosition.none,
+        );
+
+  /// Save last position of the grid view scroll controller
+  double _lastScrollOffset = 0.0;
+  double _lastEndScrollOffset = 0.0;
+
+  /// Scroll offset position to jump to after the viewer is expanded
+  double? _scrollTargetOffset;
+
+  final ValueNotifier<double> _viewerPosition = ValueNotifier<double>(0);
+  final ValueNotifier<AssetEntity?> _previewAsset =
+      ValueNotifier<AssetEntity?>(null);
+
+  @override
+  void initState(AssetPickerState<AssetEntity, AssetPathEntity> state) {
+    super.initState(state);
+  }
+
+  @override
+  void dispose() {
+    if (!keepScrollOffset) {
+      _viewerPosition.dispose();
+      _previewAsset.dispose();
+    }
+    super.dispose();
+  }
+
+  /// Returns thumbnail [index] position in scroll view
+  double indexPosition(BuildContext context, int index) {
+    final int row = (index / gridCount).floor();
+    final double size =
+        (MediaQuery.of(context).size.width - itemSpacing * (gridCount - 1)) /
+            gridCount;
+    return row * size + (row * itemSpacing);
+  }
+
+  void _expandViewer([double? scrollOffset]) {
+    _scrollTargetOffset = scrollOffset;
+    _viewerPosition.value = _kExtendedViewerPosition;
+  }
+
+  void unSelectAll() {
+    provider.selectedAssets = <AssetEntity>[];
+    _previewAsset.value = null;
+  }
+
+  /// Initialize [_previewAsset] with [p.selectedAssets] if not empty
+  /// otherwise if the first item of the album
+  Future<void> _initializePreviewAsset(
+    DefaultAssetPickerProvider p,
+    bool shouldDisplayAssets,
+  ) async {
+    if (_previewAsset.value != null) {
+      return;
+    }
+
+    if (p.selectedAssets.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _previewAsset.value = p.selectedAssets.last,
+      );
+    }
+
+    // when asset list is available and no asset is selected,
+    // preview the first of the list
+    if (shouldDisplayAssets && p.selectedAssets.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        final List<AssetEntity>? list =
+            await p.currentPath?.path.getAssetListRange(start: 0, end: 1);
+        if (list?.isNotEmpty ?? false) {
+          _previewAsset.value = list!.first;
+        }
+      });
+    }
+  }
+
+  @override
+  Future<void> viewAsset(
+    BuildContext context,
+    int index,
+    AssetEntity currentAsset,
+  ) async {
+    // if is preview asset, unselect it
+    if (provider.selectedAssets.isNotEmpty &&
+        _previewAsset.value == currentAsset) {
+      selectAsset(context, currentAsset, index, true);
+      _previewAsset.value = provider.selectedAssets.isEmpty
+          ? currentAsset
+          : provider.selectedAssets.last;
+      return;
+    }
+
+    _previewAsset.value = currentAsset;
+    selectAsset(context, currentAsset, index, false);
+  }
+
+  @override
+  Future<void> selectAsset(
+    BuildContext context,
+    AssetEntity asset,
+    int index,
+    bool selected,
+  ) async {
+    final double thumbnailPosition = indexPosition(context, index);
+    final int prevCount = provider.selectedAssets.length;
+    await super.selectAsset(context, asset, index, selected);
+
+    // update preview asset with selected
+    final List<AssetEntity> selectedAssets = provider.selectedAssets;
+    if (prevCount < selectedAssets.length) {
+      _previewAsset.value = asset;
+    } else if (selected &&
+        asset == _previewAsset.value &&
+        selectedAssets.isNotEmpty) {
+      _previewAsset.value = selectedAssets.last;
+    }
+
+    _expandViewer(thumbnailPosition);
+  }
+
+  /// Handle scroll on grid view to hide/expand the viewer
+  bool _handleScroll(
+    BuildContext context,
+    ScrollNotification notification,
+    double position,
+    double reducedPosition,
+  ) {
+    final bool isScrollUp = gridScrollController.position.userScrollDirection ==
+        ScrollDirection.reverse;
+    final bool isScrollDown =
+        gridScrollController.position.userScrollDirection ==
+            ScrollDirection.forward;
+
+    if (notification is ScrollEndNotification) {
+      _lastEndScrollOffset = gridScrollController.offset;
+      // reduce viewer
+      if (position > reducedPosition && position < _kExtendedViewerPosition) {
+        _viewerPosition.value = reducedPosition;
+        return true;
+      }
+    }
+
+    // expand viewer
+    if (isScrollDown &&
+        gridScrollController.offset < 0 &&
+        position < _kExtendedViewerPosition) {
+      // if scroll at edge, compute position based on scroll
+      if (_lastScrollOffset > gridScrollController.offset) {
+        _viewerPosition.value -=
+            (_lastScrollOffset.abs() - gridScrollController.offset.abs()) * 6;
+      } else {
+        // otherwise just expand it
+        _expandViewer();
+      }
+    } else if (isScrollUp &&
+        (gridScrollController.offset - _lastEndScrollOffset) * 1.4 >
+            MediaQuery.of(context).size.width - position &&
+        position > reducedPosition) {
+      // reduce viewer
+      _viewerPosition.value = MediaQuery.of(context).size.width -
+          (gridScrollController.offset - _lastEndScrollOffset) * 1.4;
+    }
+
+    _lastScrollOffset = gridScrollController.offset;
+
+    return true;
+  }
+
+  Widget _buildEntityViewer(BuildContext context, double opacity) {
+    return Listener(
+      onPointerDown: (_) {
+        _expandViewer();
+        // stop scroll event
+        if (gridScrollController.hasClients) {
+          gridScrollController.jumpTo(gridScrollController.offset);
+        }
+      },
+      child: Opacity(
+        opacity: opacity,
+        child: ValueListenableBuilder<AssetEntity?>(
+          valueListenable: _previewAsset,
+          builder: (_, AssetEntity? previewAsset, __) =>
+              Selector<DefaultAssetPickerProvider, List<AssetEntity>>(
+            selector: (_, DefaultAssetPickerProvider p) => p.selectedAssets,
+            builder: (_, List<AssetEntity> selected, __) {
+              final int effectiveIndex =
+                  selected.isEmpty ? 0 : selected.indexOf(selected.last);
+
+              if (previewAsset == null && selected.isEmpty) {
+                return SizedBox.square(
+                  dimension: MediaQuery.of(context).size.width,
+                  child: loadingIndicator(context),
+                );
+              }
+
+              final List<AssetEntity> assets =
+                  selected.isEmpty ? <AssetEntity>[previewAsset!] : selected;
+
+              return AssetPickerViewer<AssetEntity, AssetPathEntity>(
+                builder: InstaAssetPickerViewerBuilder(
+                  currentIndex: effectiveIndex,
+                  previewAssets: assets,
+                  themeData: theme,
+                  selectorProvider: provider,
+                  selectPredicate: selectPredicate,
+                  selectedAssets: assets,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget androidLayout(BuildContext context) {
+    // height of appbar + viewer + path selector row
+    final double topWidgetHeight = MediaQuery.of(context).size.width +
+        kToolbarHeight +
+        _kPathSelectorRowHeight +
+        MediaQuery.of(context).padding.top;
+
+    return ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+      value: provider,
+      builder: (BuildContext context, _) => ValueListenableBuilder<double>(
+        valueListenable: _viewerPosition,
+        builder: (BuildContext context, double position, _) {
+          // the top position when the viewer is reduced
+          final double topReducedPosition =
+              -(MediaQuery.of(context).size.width -
+                  _kReducedViewerHeight +
+                  kToolbarHeight);
+          position =
+              position.clamp(topReducedPosition, _kExtendedViewerPosition);
+          // opacity is calculated based on the position of the viewer
+          final double opacity =
+              ((position / -topReducedPosition) + 1).clamp(0.4, 1.0);
+          final Duration animationDuration = position == topReducedPosition ||
+                  position == _kExtendedViewerPosition
+              ? const Duration(milliseconds: 250)
+              : Duration.zero;
+
+          double gridHeight = MediaQuery.of(context).size.height -
+              kToolbarHeight -
+              _kReducedViewerHeight;
+          // when not assets are displayed, compute the exact height to show the loader
+          if (!provider.hasAssetsToDisplay) {
+            gridHeight -=
+                MediaQuery.of(context).size.width - -_viewerPosition.value;
+          }
+          final double topPadding = topWidgetHeight + position;
+          if (gridScrollController.hasClients && _scrollTargetOffset != null) {
+            gridScrollController.jumpTo(_scrollTargetOffset!);
+          }
+          _scrollTargetOffset = null;
+
+          return Stack(
+            children: <Widget>[
+              AnimatedPadding(
+                padding: EdgeInsets.only(top: topPadding),
+                duration: animationDuration,
+                child: SizedBox(
+                  height: gridHeight,
+                  width: MediaQuery.of(context).size.width,
+                  child: NotificationListener<ScrollNotification>(
+                    onNotification: (ScrollNotification notification) =>
+                        _handleScroll(
+                      context,
+                      notification,
+                      position,
+                      topReducedPosition,
+                    ),
+                    child: _buildGrid(context),
+                  ),
+                ),
+              ),
+              AnimatedPositioned(
+                top: position,
+                duration: animationDuration,
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width,
+                  height: topWidgetHeight,
+                  child: AssetPickerAppBarWrapper(
+                    appBar: AssetPickerAppBar(
+                      leading: backButton(context),
+                      actions: <Widget>[confirmButton(context)],
+                    ),
+                    body: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: pickerTheme?.canvasColor,
+                      ),
+                      child: Column(
+                        children: <Widget>[
+                          _buildEntityViewer(context, opacity),
+                          SizedBox(
+                            height: _kPathSelectorRowHeight,
+                            width: MediaQuery.of(context).size.width,
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: <Widget>[
+                                pathEntitySelector(context),
+                                IconButton(
+                                  onPressed: unSelectAll,
+                                  icon: const Icon(
+                                    Icons.layers_clear_sharp,
+                                    size: 18,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              pathEntityListBackdrop(context),
+              _buildListAlbums(context),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget appleOSLayout(BuildContext context) => androidLayout(context);
+
+  Widget _buildListAlbums(BuildContext context) {
+    return Consumer<DefaultAssetPickerProvider>(
+      builder: (BuildContext context, DefaultAssetPickerProvider provider, __) {
+        if (isAppleOS) {
+          return pathEntityListWidget(context);
+        }
+
+        // NOTE: fix position on android, quite hacky could be optimized
+        return ValueListenableBuilder<bool>(
+          valueListenable: isSwitchingPath,
+          builder: (_, bool isSwitchingPath, Widget? child) =>
+              Transform.translate(
+            offset: isSwitchingPath
+                ? Offset(0, kToolbarHeight + MediaQuery.of(context).padding.top)
+                : Offset.zero,
+            child: Stack(
+              children: <Widget>[pathEntityListWidget(context)],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildGrid(BuildContext context) {
+    return Consumer<DefaultAssetPickerProvider>(
+      builder: (BuildContext context, DefaultAssetPickerProvider p, __) {
+        final bool shouldDisplayAssets =
+            p.hasAssetsToDisplay || shouldBuildSpecialItem;
+        _initializePreviewAsset(p, shouldDisplayAssets);
+
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: shouldDisplayAssets
+              ? MediaQuery(
+                  // fix: https://github.com/fluttercandies/flutter_wechat_assets_picker/issues/395
+                  data: MediaQuery.of(context).copyWith(
+                    padding: const EdgeInsets.only(top: -kToolbarHeight),
+                  ),
+                  child: RepaintBoundary(child: assetsGridBuilder(context)),
+                )
+              : loadingIndicator(context),
+        );
+      },
+    );
+  }
+
+  /// To show selected assets indicator and preview asset overlay
+  @override
+  Widget selectIndicator(BuildContext context, int index, AssetEntity asset) {
+    final List<AssetEntity> selectedAssets = provider.selectedAssets;
+    final Duration duration = switchingPathDuration * 0.75;
+
+    final int indexSelected = selectedAssets.indexOf(asset);
+    final bool isSelected = indexSelected != -1;
+
+    final Widget innerSelector = AnimatedContainer(
+      duration: duration,
+      width: _kIndicatorSize,
+      height: _kIndicatorSize,
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.selectedRowColor),
+        color: isSelected ? themeColor : theme.selectedRowColor.withOpacity(.2),
+        shape: BoxShape.circle,
+      ),
+      child: FittedBox(
+        child: AnimatedSwitcher(
+          duration: duration,
+          reverseDuration: duration,
+          child: isSelected
+              ? Text((indexSelected + 1).toString())
+              : const SizedBox.shrink(),
+        ),
+      ),
+    );
+
+    return ValueListenableBuilder<AssetEntity?>(
+      valueListenable: _previewAsset,
+      builder:
+          (BuildContext context, AssetEntity? previewAsset, Widget? child) {
+        final bool isPreview = asset == _previewAsset.value;
+
+        return Positioned.fill(
+          child: GestureDetector(
+            onTap: isPreviewEnabled
+                ? () => viewAsset(context, index, asset)
+                : null,
+            child: AnimatedContainer(
+              duration: switchingPathDuration,
+              padding: const EdgeInsets.all(4),
+              color: isPreview
+                  ? theme.selectedRowColor.withOpacity(.5)
+                  : theme.backgroundColor.withOpacity(.1),
+              child: Align(
+                alignment: AlignmentDirectional.topEnd,
+                child: isSelected && !isSingleAssetMode
+                    ? GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () =>
+                            selectAsset(context, asset, index, isSelected),
+                        child: innerSelector,
+                      )
+                    : innerSelector,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget selectedBackdrop(BuildContext context, int index, AssetEntity asset) =>
+      const SizedBox.shrink();
+}
+
+class InstaAssetPickerViewerBuilder
+    extends DefaultAssetPickerViewerBuilderDelegate {
+  InstaAssetPickerViewerBuilder({
+    required super.currentIndex,
+    required super.previewAssets,
+    required super.themeData,
+    super.selectorProvider,
+    super.provider,
+    super.selectedAssets,
+    super.maxAssets,
+    super.shouldReversePreview,
+    super.selectPredicate,
+  });
+
+  @override
+  Widget build(BuildContext context) => SizedBox.square(
+        dimension: MediaQuery.of(context).size.width,
+        child: assetPageBuilder(context, currentIndex),
+      );
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_assets_picker_demo
 description: The demo project for the wechat_assets_picker package.
-version: 8.3.0+31
+version: 8.3.1+32
 publish_to: none
 
 environment:

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -159,6 +159,7 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
 
   /// Call when viewer is calling [State.initState].
   /// 当预览器调用 [State.initState] 时注册 [State] 和 [TickerProvider]。
+  @mustCallSuper
   void initStateAndTicker(
     AssetPickerViewerState<Asset, Path> s,
     TickerProvider v,
@@ -177,6 +178,7 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
 
   /// Call when the viewer is calling [State.didUpdateWidget].
   /// 当预览器调用 [State.didUpdateWidget] 时操作 [State] 和 [TickerProvider]。
+  @mustCallSuper
   void didUpdateViewer(
     covariant AssetPickerViewerState<Asset, Path> state,
     covariant AssetPickerViewer<Asset, Path> oldWidget,
@@ -189,6 +191,7 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
 
   /// Keep a dispose method to sync with [State].
   /// 保留一个 dispose 方法与 [State] 同步。
+  @mustCallSuper
   void dispose() {
     provider?.dispose();
     pageController.dispose();

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -175,6 +175,18 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
     );
   }
 
+  /// Call when the viewer is calling [State.didUpdateWidget].
+  /// 当预览器调用 [State.didUpdateWidget] 时操作 [State] 和 [TickerProvider]。
+  void didUpdateViewer(
+    covariant AssetPickerViewerState<Asset, Path> state,
+    covariant AssetPickerViewer<Asset, Path> oldWidget,
+    covariant AssetPickerViewer<Asset, Path> newWidget,
+  ) {
+    doubleTapAnimationController =
+        oldWidget.builder.doubleTapAnimationController;
+    doubleTapCurveAnimation = oldWidget.builder.doubleTapCurveAnimation;
+  }
+
   /// Keep a dispose method to sync with [State].
   /// 保留一个 dispose 方法与 [State] 同步。
   void dispose() {

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -93,19 +93,15 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
 
   /// The [State] for a viewer.
   /// 预览器的状态实例
-  late final AssetPickerViewerState<Asset, Path> viewerState;
-
-  /// The [TickerProvider] for animations.
-  /// 用于动画的 [TickerProvider]
-  late final TickerProvider vsync;
+  late AssetPickerViewerState<Asset, Path> viewerState;
 
   /// [AnimationController] for double tap animation.
   /// 双击缩放的动画控制器
-  late final AnimationController doubleTapAnimationController;
+  late AnimationController doubleTapAnimationController;
 
   /// [CurvedAnimation] for double tap.
   /// 双击缩放的动画曲线
-  late final Animation<double> doubleTapCurveAnimation;
+  late Animation<double> doubleTapCurveAnimation;
 
   /// [Animation] for double tap.
   /// 双击缩放的动画
@@ -158,35 +154,30 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
       Singleton.textDelegate.semanticsTextDelegate;
 
   /// Call when viewer is calling [State.initState].
-  /// 当预览器调用 [State.initState] 时注册 [State] 和 [TickerProvider]。
+  /// 当预览器调用 [State.initState] 时注册 [State]。
   @mustCallSuper
   void initStateAndTicker(
-    AssetPickerViewerState<Asset, Path> s,
-    TickerProvider v,
+    covariant AssetPickerViewerState<Asset, Path> state,
+    TickerProvider v, // TODO(Alex): Remove this in the next major version.
   ) {
-    viewerState = s;
-    vsync = v;
-    doubleTapAnimationController = AnimationController(
-      duration: const Duration(milliseconds: 200),
-      vsync: v,
-    );
-    doubleTapCurveAnimation = CurvedAnimation(
-      parent: doubleTapAnimationController,
-      curve: Curves.easeInOut,
-    );
+    initAnimations(state);
   }
 
   /// Call when the viewer is calling [State.didUpdateWidget].
-  /// 当预览器调用 [State.didUpdateWidget] 时操作 [State] 和 [TickerProvider]。
+  /// 当预览器调用 [State.didUpdateWidget] 时操作 [State]。
+  ///
+  /// Since delegates are relatively "Stateless" compare to the
+  /// [AssetPickerViewerState], the widget that holds the delegate might changed
+  /// when using the viewer as a nested widget, which will construct
+  /// a new delegate and only calling [State.didUpdateWidget] at the moment.
   @mustCallSuper
   void didUpdateViewer(
     covariant AssetPickerViewerState<Asset, Path> state,
     covariant AssetPickerViewer<Asset, Path> oldWidget,
     covariant AssetPickerViewer<Asset, Path> newWidget,
   ) {
-    doubleTapAnimationController =
-        oldWidget.builder.doubleTapAnimationController;
-    doubleTapCurveAnimation = oldWidget.builder.doubleTapCurveAnimation;
+    // Widgets are useless in the default delegate.
+    initAnimations(state);
   }
 
   /// Keep a dispose method to sync with [State].
@@ -203,6 +194,20 @@ abstract class AssetPickerViewerBuilderDelegate<Asset, Path> {
       ..stop()
       ..reset()
       ..dispose();
+  }
+
+  /// Initialize animations related to the zooming preview.
+  /// 为缩放预览初始化动画
+  void initAnimations(covariant AssetPickerViewerState<Asset, Path> state) {
+    viewerState = state;
+    doubleTapAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: state,
+    );
+    doubleTapCurveAnimation = CurvedAnimation(
+      parent: doubleTapAnimationController,
+      curve: Curves.easeInOut,
+    );
   }
 
   /// Produce [OrdinalSortKey] with the fixed name.

--- a/lib/src/widget/asset_picker_viewer.dart
+++ b/lib/src/widget/asset_picker_viewer.dart
@@ -110,6 +110,12 @@ class AssetPickerViewerState<Asset, Path>
   }
 
   @override
+  void didUpdateWidget(covariant AssetPickerViewer<Asset, Path> oldWidget) {
+    builder.initStateAndTicker(this, this);
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   void dispose() {
     builder.dispose();
     super.dispose();

--- a/lib/src/widget/asset_picker_viewer.dart
+++ b/lib/src/widget/asset_picker_viewer.dart
@@ -111,8 +111,8 @@ class AssetPickerViewerState<Asset, Path>
 
   @override
   void didUpdateWidget(covariant AssetPickerViewer<Asset, Path> oldWidget) {
-    builder.initStateAndTicker(this, this);
     super.didUpdateWidget(oldWidget);
+    builder.didUpdateViewer(this, oldWidget, widget);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   An audio/video/image picker in pure Dart which is the same with WeChat,
   support multi picking, custom item and delegates override.
 repository: https://github.com/fluttercandies/flutter_wechat_assets_picker
-version: 8.3.0
+version: 8.3.1
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
As we discussed previously #399.
Introduce `InstaAssetPickerBuilder` based on [insta_assets_picker](https://github.com/LeGoffMael/insta_assets_picker) which reproduces instagram layout.

### This custom delegate show how to:
- setup a complete different: layout, select and view logic
- use `keepScrollOffset` when set to true to restore scroll and preview
- customize `DefaultAssetPickerViewerBuilderDelegate` (currently there is no example for it)

Tested on both iOS and Android.

### Changes needed outside of example folder
- Fixed an issue in `AssetPickerViewer`, when not used in a new pushed route, `initStateAndTicker` would be omitted.

## Record
<video src="https://user-images.githubusercontent.com/22376981/209911099-26c718b9-cc0b-495d-8b52-b3d5fff0ab46.mov"/>
