### PR TITLE
Migrate `extended_image` to `^7.0.0` and fix some deprecated changes

### DIFF
--- a/example/lib/customs/custom_picker_page.dart
+++ b/example/lib/customs/custom_picker_page.dart
@@ -124,7 +124,7 @@ class _MethodListView extends StatelessWidget {
                   const SizedBox(height: 5),
                   Text(
                     model.description,
-                    style: Theme.of(context).textTheme.caption,
+                    style: Theme.of(context).textTheme.bodySmall,
                     overflow: TextOverflow.fade,
                   ),
                 ],

--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -808,8 +808,8 @@ class FileAssetPickerBuilder
                   : textDelegate.confirm,
               style: TextStyle(
                 color: provider.isSelectedNotEmpty
-                    ? theme.textTheme.bodyText1?.color
-                    : theme.textTheme.caption?.color,
+                    ? theme.textTheme.bodyLarge?.color
+                    : theme.textTheme.bodySmall?.color,
                 fontSize: 17.0,
                 fontWeight: FontWeight.normal,
               ),
@@ -1066,7 +1066,7 @@ class FileAssetPickerBuilder
                   style: TextStyle(
                     color: isSelectedNotEmpty
                         ? null
-                        : theme.textTheme.caption?.color,
+                        : theme.textTheme.bodySmall?.color,
                     fontSize: 18.0,
                   ),
                 );
@@ -1129,7 +1129,7 @@ class FileAssetPickerBuilder
                               '${index + 1}',
                               style: TextStyle(
                                 color: isSelected
-                                    ? theme.textTheme.bodyText1?.color
+                                    ? theme.textTheme.bodyLarge?.color
                                     : null,
                                 fontSize: isAppleOS ? 16.0 : 14.0,
                                 fontWeight: isAppleOS
@@ -1493,8 +1493,8 @@ class FileAssetPickerViewerBuilderDelegate
               style: TextStyle(
                 color: () {
                   return provider.isSelectedNotEmpty
-                      ? themeData.textTheme.bodyText1?.color
-                      : themeData.textTheme.caption?.color;
+                      ? themeData.textTheme.bodyLarge?.color
+                      : themeData.textTheme.bodySmall?.color;
                 }(),
                 fontSize: 17.0,
                 fontWeight: FontWeight.normal,

--- a/example/lib/customs/pickers/insta_asset_picker.dart
+++ b/example/lib/customs/pickers/insta_asset_picker.dart
@@ -715,7 +715,7 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
               padding: const EdgeInsets.all(4),
               color: isPreview
                   ? theme.selectedRowColor.withOpacity(.5)
-                  : theme.backgroundColor.withOpacity(.1),
+                  : theme.colorScheme.background.withOpacity(.1),
               child: Align(
                 alignment: AlignmentDirectional.topEnd,
                 child: isSelected && !isSingleAssetMode

--- a/example/lib/customs/pickers/insta_asset_picker.dart
+++ b/example/lib/customs/pickers/insta_asset_picker.dart
@@ -298,11 +298,6 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
       ValueNotifier<AssetEntity?>(null);
 
   @override
-  void initState(AssetPickerState<AssetEntity, AssetPathEntity> state) {
-    super.initState(state);
-  }
-
-  @override
   void dispose() {
     if (!keepScrollOffset) {
       _viewerPosition.dispose();

--- a/example/lib/customs/pickers/multi_tabs_assets_picker.dart
+++ b/example/lib/customs/pickers/multi_tabs_assets_picker.dart
@@ -408,8 +408,8 @@ class MultiTabAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
                 : textDelegate.confirm,
             style: TextStyle(
               color: p.isSelectedNotEmpty
-                  ? theme.textTheme.bodyText1?.color
-                  : theme.textTheme.caption?.color,
+                  ? theme.textTheme.bodyLarge?.color
+                  : theme.textTheme.bodySmall?.color,
               fontSize: 17,
               fontWeight: FontWeight.normal,
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,10 +59,10 @@ class NoGlowScrollBehavior extends ScrollBehavior {
   const NoGlowScrollBehavior();
 
   @override
-  Widget buildViewportChrome(
+  Widget buildOverscrollIndicator(
     BuildContext context,
     Widget child,
-    AxisDirection axisDirection,
+    ScrollableDetails details,
   ) =>
       child;
 }

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -76,14 +76,14 @@ class _HomePageState extends State<HomePage> {
                 sortKey: const OrdinalSortKey(0),
                 child: Text(
                   'WeChat Asset Picker',
-                  style: Theme.of(context).textTheme.headline6,
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
               ),
               Semantics(
                 sortKey: const OrdinalSortKey(0.1),
                 child: Text(
                   'Version: ${packageVersion ?? 'unknown'}',
-                  style: Theme.of(context).textTheme.caption,
+                  style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
             ],

--- a/example/lib/widgets/method_list_view.dart
+++ b/example/lib/widgets/method_list_view.dart
@@ -64,7 +64,7 @@ class _MethodListViewState extends State<MethodListView> {
                   const SizedBox(height: 5),
                   Text(
                     model.description,
-                    style: Theme.of(context).textTheme.caption,
+                    style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ],
               ),

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -403,7 +403,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
             textDelegate.gifIndicator,
             style: TextStyle(
               color: isAppleOS
-                  ? theme.textTheme.bodyText2?.color
+                  ? theme.textTheme.bodyMedium?.color
                   : theme.primaryColor,
               fontSize: 13,
               fontWeight: FontWeight.w500,
@@ -493,7 +493,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
             Expanded(
               child: ScaleText(
                 textDelegate.accessAllTip,
-                style: context.themeData.textTheme.caption?.copyWith(
+                style: context.themeData.textTheme.bodySmall?.copyWith(
                   fontSize: 14,
                 ),
                 semanticsLabel: semanticsTextDelegate.accessAllTip,
@@ -1513,8 +1513,8 @@ class DefaultAssetPickerBuilderDelegate
                 : textDelegate.confirm,
             style: TextStyle(
               color: p.isSelectedNotEmpty
-                  ? theme.textTheme.bodyText1?.color
-                  : theme.textTheme.caption?.color,
+                  ? theme.textTheme.bodyLarge?.color
+                  : theme.textTheme.bodySmall?.color,
               fontSize: 17,
               fontWeight: FontWeight.normal,
             ),
@@ -1657,7 +1657,7 @@ class DefaultAssetPickerBuilderDelegate
                       ),
                     ],
                   ),
-                  style: context.themeData.textTheme.caption?.copyWith(
+                  style: context.themeData.textTheme.bodySmall?.copyWith(
                     fontSize: 14,
                   ),
                 ),
@@ -1888,7 +1888,7 @@ class DefaultAssetPickerBuilderDelegate
                                 ScaleText(
                                   '($semanticsCount)',
                                   style: TextStyle(
-                                    color: theme.textTheme.caption?.color,
+                                    color: theme.textTheme.bodySmall?.color,
                                     fontSize: 17,
                                   ),
                                   maxLines: 1,
@@ -1970,7 +1970,7 @@ class DefaultAssetPickerBuilderDelegate
                 style: TextStyle(
                   color: p.isSelectedNotEmpty
                       ? null
-                      : c.themeData.textTheme.caption?.color,
+                      : c.themeData.textTheme.bodySmall?.color,
                   fontSize: 17,
                 ),
                 maxScaleFactor: 1.2,
@@ -2075,7 +2075,7 @@ class DefaultAssetPickerBuilderDelegate
               padding: EdgeInsets.all(indicatorSize * .35),
               color: selected
                   ? theme.colorScheme.primary.withOpacity(.45)
-                  : theme.backgroundColor.withOpacity(.1),
+                  : theme.colorScheme.background.withOpacity(.1),
               child: selected && !isSingleAssetMode
                   ? Align(
                       alignment: AlignmentDirectional.topStart,
@@ -2087,7 +2087,7 @@ class DefaultAssetPickerBuilderDelegate
                           child: Text(
                             '${index + 1}',
                             style: TextStyle(
-                              color: theme.textTheme.bodyText1?.color
+                              color: theme.textTheme.bodyLarge?.color
                                   ?.withOpacity(.75),
                               fontWeight: FontWeight.w600,
                               height: 1,

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -860,7 +860,7 @@ class DefaultAssetPickerViewerBuilderDelegate
             child: ScaleText(
               buildText(),
               style: TextStyle(
-                color: themeData.textTheme.bodyText1?.color,
+                color: themeData.textTheme.bodyLarge?.color,
                 fontSize: 17,
                 fontWeight: FontWeight.normal,
               ),

--- a/lib/src/widget/asset_picker_app_bar.dart
+++ b/lib/src/widget/asset_picker_app_bar.dart
@@ -131,7 +131,7 @@ class AssetPickerAppBar extends StatelessWidget implements PreferredSizeWidget {
                     ? Alignment.center
                     : AlignmentDirectional.centerStart,
                 child: DefaultTextStyle(
-                  style: theme.textTheme.headline6!.copyWith(fontSize: 23.0),
+                  style: theme.textTheme.titleLarge!.copyWith(fontSize: 23.0),
                   maxLines: 1,
                   softWrap: false,
                   overflow: TextOverflow.ellipsis,

--- a/lib/src/widget/builder/audio_page_builder.dart
+++ b/lib/src/widget/builder/audio_page_builder.dart
@@ -168,7 +168,7 @@ class _AudioPageBuilderState extends State<AudioPageBuilder> {
       onLongPressHint:
           Singleton.textDelegate.semanticsTextDelegate.sActionPlayHint,
       child: ColoredBox(
-        color: context.themeData.backgroundColor,
+        color: context.themeData.colorScheme.background,
         child: isLoaded
             ? Column(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/widget/builder/locally_available_builder.dart
+++ b/lib/src/widget/builder/locally_available_builder.dart
@@ -97,7 +97,7 @@ class _LocallyAvailableBuilderState extends State<LocallyAvailableBuilder> {
                 ScaleText(
                   '  iCloud ${(progress * 100).toInt()}%',
                   style: TextStyle(
-                    color: context.themeData.textTheme.bodyText2?.color
+                    color: context.themeData.textTheme.bodyMedium?.color
                         ?.withOpacity(.4),
                   ),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  extended_image: ^6.2.0
+  extended_image: ^7.0.0
   photo_manager: ^2.4.0
   provider: ^6.0.2
   video_player: ^2.4.0


### PR DESCRIPTION
- Migrate `extended_image` `^6.2.0` to `^7.0.0`
- Fix some deprecated changes from Material Theme System Updates
- Fix a deprecated override of `buildViewportChrome` (https://github.com/flutter/flutter/pull/111715)
- Remove a unnecessary override