### PR TITLE
🚸 Allow to confirm 0 assets if there are selected assets previously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that can be found in the LICENSE file. -->
 
 - Sync all UI details from WeChat 8.3.x. (#458)
 - Add Turkish language text delegate. (#331).
+- Allow to confirm 0 assets if there are selected assets previously. (#461)
 
 ### Fixes
 

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1480,8 +1480,11 @@ class DefaultAssetPickerBuilderDelegate
   Widget confirmButton(BuildContext context) {
     return Consumer<DefaultAssetPickerProvider>(
       builder: (_, DefaultAssetPickerProvider p, __) {
+        final bool isSelectedNotEmpty = p.isSelectedNotEmpty;
+        final bool shouldAllowConfirm =
+            isSelectedNotEmpty || p.previousSelectedAssets.isNotEmpty;
         return MaterialButton(
-          minWidth: p.isSelectedNotEmpty ? 48 : 20,
+          minWidth: shouldAllowConfirm ? 48 : 20,
           height: appBarItemHeight,
           padding: const EdgeInsets.symmetric(horizontal: 12),
           color: theme.colorScheme.secondary,
@@ -1489,23 +1492,23 @@ class DefaultAssetPickerBuilderDelegate
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(3),
           ),
-          onPressed: p.isSelectedNotEmpty
+          onPressed: shouldAllowConfirm
               ? () => Navigator.of(context).maybePop(p.selectedAssets)
               : null,
           materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           child: ScaleText(
-            p.isSelectedNotEmpty && !isSingleAssetMode
+            isSelectedNotEmpty && !isSingleAssetMode
                 ? '${textDelegate.confirm}'
                     ' (${p.selectedAssets.length}/${p.maxAssets})'
                 : textDelegate.confirm,
             style: TextStyle(
-              color: p.isSelectedNotEmpty
+              color: shouldAllowConfirm
                   ? theme.textTheme.bodyLarge?.color
                   : theme.textTheme.bodySmall?.color,
               fontSize: 17,
               fontWeight: FontWeight.normal,
             ),
-            semanticsLabel: p.isSelectedNotEmpty && !isSingleAssetMode
+            semanticsLabel: isSelectedNotEmpty && !isSingleAssetMode
                 ? '${semanticsTextDelegate.confirm}'
                     ' (${p.selectedAssets.length}/${p.maxAssets})'
                 : semanticsTextDelegate.confirm,

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -28,11 +28,11 @@ abstract class AssetPickerProvider<Asset, Path> extends ChangeNotifier {
     this.pathThumbnailSize = defaultPathThumbnailSize,
     List<Asset>? selectedAssets,
   })  : assert(maxAssets > 0, 'maxAssets must be greater than 0.'),
-        assert(pageSize > 0, 'pageSize must be greater than 0.') {
-    if (selectedAssets != null && selectedAssets.isNotEmpty) {
-      _selectedAssets = selectedAssets.toList();
-    }
-  }
+        assert(pageSize > 0, 'pageSize must be greater than 0.'),
+        _previousSelectedAssets =
+            selectedAssets?.toList(growable: false) ?? List<Asset>.empty(),
+        _selectedAssets =
+            selectedAssets?.toList() ?? List<Asset>.empty(growable: true);
 
   /// Maximum count for asset selection.
   /// 资源选择的最大数量
@@ -177,10 +177,15 @@ abstract class AssetPickerProvider<Asset, Path> extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Selected assets before the picker starts picking.
+  /// 选择器开始选择前已选中的资源
+  List<Asset> get previousSelectedAssets => _previousSelectedAssets;
+  final List<Asset> _previousSelectedAssets;
+
   /// Selected assets.
   /// 已选中的资源
   List<Asset> get selectedAssets => _selectedAssets;
-  List<Asset> _selectedAssets = <Asset>[];
+  late List<Asset> _selectedAssets;
 
   set selectedAssets(List<Asset> value) {
     if (value == _selectedAssets) {


### PR DESCRIPTION
Resolves #455.