### PR TITLE
⚡️ Split assets fetching into separate steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ that can be found in the LICENSE file. -->
 - Support limited permission displays on Android.
 - Improves the limited overlay padding on Android.
 - Adds permission request lock for the picker state.
-
-## 9.0.5
+- Speeding up by splitting asset loading into separate steps.
+- Speeding up using `AdvancedCustomFilter` rather than `FilterOptionGroup` by default.
 
 ### Fixes
 

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -332,14 +332,17 @@ class DefaultAssetPickerProvider
   Future<void> getPaths({bool onlyAll = false}) async {
     final PMFilter options;
     final fog = filterOptions;
-    if (fog is FilterOptionGroup?) {
-      // Initial base options.
-      // Enable need title for audios to get proper display.
+    if (fog == null) {
+      options = AdvancedCustomFilter(
+        orderBy: [OrderByItem.desc(CustomColumns.base.createDate)],
+      );
+    } else if (fog is FilterOptionGroup) {
       final newOptions = FilterOptionGroup(
         imageOption: const FilterOption(
           sizeConstraint: SizeConstraint(ignoreSize: true),
         ),
         audioOption: const FilterOption(
+          // Enable title for audios to get proper display.
           needTitle: true,
           sizeConstraint: SizeConstraint(ignoreSize: true),
         ),
@@ -347,10 +350,7 @@ class DefaultAssetPickerProvider
         createTimeCond: DateTimeCond.def().copyWith(ignore: true),
         updateTimeCond: DateTimeCond.def().copyWith(ignore: true),
       );
-      // Merge user's filter options into base options if it's not null.
-      if (fog != null) {
-        newOptions.merge(fog);
-      }
+      newOptions.merge(fog);
       options = newOptions;
     } else {
       options = fog;

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -3,6 +3,7 @@
 // in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -121,8 +122,12 @@ class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
       requestPermission().then((ps) {
-        if (mounted) {
-          widget.builder.permission.value = ps;
+        if (!mounted) {
+          return;
+        }
+        widget.builder.permission.value = ps;
+        if (ps == PermissionState.limited && Platform.isAndroid) {
+          _onLimitedAssetsUpdated(const MethodCall(''));
         }
       });
     }


### PR DESCRIPTION
### Changes
1. Change the fetching steps to loading the first album first, then the others.
2. Use `AdvancedCustomFilter` by default to order items in desc without extra search queries to decrease the query complexity.

- Resolves #496
- Resolves #526
- Resolves #547
