### PR TITLE
🐛 Fixes permission requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ that can be found in the LICENSE file. -->
 > [!IMPORTANT]  
 > See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
 
+## 9.1.0
+
+### Fixes
+
+- Requests with the correct options with the picker.
+
+### Improvements
+
+- Support limited permission displays on Android.
+- Improves the limited overlay padding on Android.
+- Adds permission request lock for the picker state.
+
 ## 9.0.5
 
 ### Fixes

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <application
         android:label="Wechat Assets Picker Example"

--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -1190,7 +1190,7 @@ class FileAssetPickerBuilder
               fit: StackFit.expand,
               children: <Widget>[
                 if (isAppleOS(context)) appleOSLayout(c) else androidLayout(c),
-                if (Platform.isIOS) iOSPermissionOverlay(c),
+                permissionOverlay(c),
               ],
             ),
           ),

--- a/example/lib/customs/pickers/multi_tabs_assets_picker.dart
+++ b/example/lib/customs/pickers/multi_tabs_assets_picker.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache license that can be found
 // in the LICENSE file.
 
-import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -562,7 +561,7 @@ class MultiTabAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
                   appleOSLayout(context)
                 else
                   androidLayout(context),
-                if (Platform.isIOS) iOSPermissionOverlay(context),
+                permissionOverlay(context),
               ],
             ),
           ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_assets_picker_demo
 description: The demo project for the wechat_assets_picker package.
-version: 9.0.5+54
+version: 9.1.0+55
 publish_to: none
 
 environment:

--- a/guides/migration_guide.md
+++ b/guides/migration_guide.md
@@ -6,8 +6,9 @@ that can be found in the LICENSE file. -->
 
 This document gathered all breaking changes and migrations requirement between major versions.
 
-## Major versions
+## Breaking changes in versions
 
+- [9.1.0](#910)
 - [9.0.0](#900)
 - [8.6.0](#860)
 - [8.3.0](#830)
@@ -16,6 +17,14 @@ This document gathered all breaking changes and migrations requirement between m
 - [7.0.0](#700)
 - [6.0.0](#600)
 - [5.0.0](#500)
+
+## 9.1.0
+
+### Deprecates `iOSPermissionOverlay`
+
+Due to the support of the limited permission status on Android,
+the permission overlay will also displays on Android.
+Thus, `iOSPermissionOverlay` is now migrating to `permissionOverlay`.
 
 ## 9.0.0
 

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache license that can be found
 // in the LICENSE file.
 
-import 'dart:io' show Platform;
 import 'dart:math' as math;
 import 'dart:typed_data' as typed_data;
 import 'dart:ui' as ui;
@@ -574,7 +573,13 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   }
 
   /// The overlay when the permission is limited on iOS.
+  @Deprecated('Use permissionOverlay instead. This will be removed in 10.0.0')
   Widget iOSPermissionOverlay(BuildContext context) {
+    return permissionOverlay(context);
+  }
+
+  /// The overlay when the permission is limited.
+  Widget permissionOverlay(BuildContext context) {
     final Size size = MediaQuery.sizeOf(context);
     final Widget closeButton = Container(
       margin: const EdgeInsetsDirectional.only(start: 16, top: 4),
@@ -652,7 +657,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
           child: Semantics(
             sortKey: const OrdinalSortKey(0),
             child: Container(
-              padding: MediaQuery.paddingOf(context),
+              padding: EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
               color: context.theme.canvasColor,
               child: Column(
                 children: <Widget>[
@@ -661,6 +666,12 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
                   goToSettingsButton,
                   SizedBox(height: size.height / 18),
                   accessLimitedButton,
+                  SizedBox(
+                    height: math.max(
+                      MediaQuery.paddingOf(context).bottom,
+                      24.0,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -2220,7 +2231,7 @@ class DefaultAssetPickerBuilderDelegate
                   appleOSLayout(context)
                 else
                   androidLayout(context),
-                if (Platform.isIOS) iOSPermissionOverlay(context),
+                permissionOverlay(context),
               ],
             ),
           ),

--- a/lib/src/delegates/asset_picker_delegate.dart
+++ b/lib/src/delegates/asset_picker_delegate.dart
@@ -96,6 +96,7 @@ class AssetPickerDelegate {
     );
     final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
       key: key,
+      permissionRequestOption: permissionRequestOption,
       builder: DefaultAssetPickerBuilderDelegate(
         provider: provider,
         initialPermission: ps,
@@ -157,6 +158,7 @@ class AssetPickerDelegate {
     await permissionCheck(requestOption: permissionRequestOption);
     final Widget picker = AssetPicker<Asset, Path>(
       key: key,
+      permissionRequestOption: permissionRequestOption,
       builder: delegate,
     );
     final List<Asset>? result = await Navigator.maybeOf(

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -15,8 +15,13 @@ import 'asset_picker_page_route.dart';
 AssetPickerDelegate _pickerDelegate = const AssetPickerDelegate();
 
 class AssetPicker<Asset, Path> extends StatefulWidget {
-  const AssetPicker({super.key, required this.builder});
+  const AssetPicker({
+    super.key,
+    required this.permissionRequestOption,
+    required this.builder,
+  });
 
+  final PermissionRequestOption permissionRequestOption;
   final AssetPickerBuilderDelegate<Asset, Path> builder;
 
   /// Provide another [AssetPickerDelegate] which override with

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wechat_assets_picker
-version: 9.0.5
+version: 9.1.0
 description: |
   An image picker (also with videos and audio)
   for Flutter projects based on WeChat's UI,

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -122,6 +122,7 @@ class TestAssetPickerDelegate extends AssetPickerDelegate {
       ..totalAssetsCount = 1;
     final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
       key: key,
+      permissionRequestOption: permissionRequestOption,
       builder: DefaultAssetPickerBuilderDelegate(
         provider: provider,
         initialPermission: ps,


### PR DESCRIPTION
- Support limited permission displays on Android. This also deprecates `iOSPermissionOverlay`.
- Requests with the correct options with the picker.
- Improves the limited overlay padding on Android.
- Adds permission request lock for the picker state.