### PR TITLE
feat: presentLimitedAndReload

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1674,7 +1674,7 @@ class DefaultAssetPickerBuilderDelegate
                 label: '${semanticsTextDelegate.viewingLimitedAssetsTip}, '
                     '${semanticsTextDelegate.changeAccessibleLimitedAssets}',
                 button: true,
-                onTap: PhotoManager.presentLimited,
+                onTap: presentLimitedAndReload,
                 hidden: !isPermissionLimited,
                 focusable: isPermissionLimited,
                 excludeSemantics: true,
@@ -1696,7 +1696,7 @@ class DefaultAssetPickerBuilderDelegate
                             '${textDelegate.changeAccessibleLimitedAssets}',
                         style: TextStyle(color: interactiveTextColor(context)),
                         recognizer: TapGestureRecognizer()
-                          ..onTap = PhotoManager.presentLimited,
+                          ..onTap = presentLimitedAndReload,
                       ),
                     ],
                   ),
@@ -1764,7 +1764,7 @@ class DefaultAssetPickerBuilderDelegate
       child: GestureDetector(
         onTap: () {
           if (isPermissionLimited && provider.isAssetsEmpty) {
-            PhotoManager.presentLimited();
+            presentLimitedAndReload();
             return;
           }
           if (provider.currentPath == null) {
@@ -2164,6 +2164,12 @@ class DefaultAssetPickerBuilderDelegate
         ),
       ),
     );
+  }
+
+  Future<void> presentLimitedAndReload() async {
+    await PhotoManager.presentLimited();
+    await provider.getPaths(onlyAll: true);
+    await provider.getPaths(onlyAll: false);
   }
 
   @override

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an Apache license that can be found
 // in the LICENSE file.
 
+import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data' as typed_data;
 import 'dart:ui' as ui;
@@ -2168,8 +2169,14 @@ class DefaultAssetPickerBuilderDelegate
 
   Future<void> presentLimitedAndReload() async {
     await PhotoManager.presentLimited();
-    await provider.getPaths(onlyAll: true);
-    await provider.getPaths(onlyAll: false);
+    // reload new image for Android
+    if (Platform.isAndroid) {
+      // 刷新权限，从旧版本 Android 升级而来的用户，在触发 presentLimited 后，可能会获得完整相册权限
+      // Update permissions. When users upgrade from older versions of Android may get full album permissions after presentLimited is called.
+      permission.value = await PhotoManager.requestPermissionExtend();
+      await provider.getPaths(onlyAll: true);
+      await provider.getPaths(onlyAll: false);
+    }
   }
 
   @override

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -512,7 +512,7 @@ class DefaultAssetPickerProvider
     PathWrapper<AssetPathEntity> path, {
     int? initAssetCount,
   }) async {
-    final assetCount = initAssetCount;
+    final assetCount = initAssetCount ?? await path.path.assetCountAsync;
     final int index = _paths.indexWhere(
       (PathWrapper<AssetPathEntity> p) => p == path,
     );

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -366,9 +366,11 @@ class DefaultAssetPickerProvider
     // Sort path using sort path delegate.
     Singleton.sortPathDelegate.sort(_paths);
     // Use sync method to avoid unnecessary wait.
-    _paths
-      ..forEach(getAssetCountFromPath)
-      ..forEach(getThumbnailFromPath);
+
+    for (final element in _paths) {
+      await getAssetCountFromPath(element);
+      await getThumbnailFromPath(element);
+    }
 
     // Set first path entity as current path entity.
     if (_paths.isNotEmpty) {

--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -368,9 +368,12 @@ class DefaultAssetPickerProvider
     // Use sync method to avoid unnecessary wait.
 
     for (final element in _paths) {
-      final assetCount = await element.path.assetCountAsync;
-      getAssetCountFromPath(element, initAssetCount: assetCount);
-      getThumbnailFromPath(element, initAssetCount: assetCount);
+      // without await for async
+      () async {
+        final assetCount = await element.path.assetCountAsync;
+        getAssetCountFromPath(element, initAssetCount: assetCount);
+        getThumbnailFromPath(element, initAssetCount: assetCount);
+      }();
     }
 
     // Set first path entity as current path entity.


### PR DESCRIPTION
1. fix https://github.com/fluttercandies/flutter_wechat_assets_picker/issues/602
2. When using `android.permission.READ_MEDIA_VISUAL_USER_SELECTED` with Android14, the images needs to be reloaded after calling `PhotoManager.presentLimited`.