### PR TITLE
fix limited permission overlay not showing in some cases

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1086,7 +1086,8 @@ class DefaultAssetPickerBuilderDelegate
                         child: Column(
                           children: <Widget>[
                             Expanded(child: assetsGridBuilder(context)),
-                            if (isPreviewEnabled || !isSingleAssetMode)
+                            if (isPreviewEnabled || !isSingleAssetMode
+                            || permissionNotifier.value == PermissionState.limited)
                               bottomActionBar(context),
                           ],
                         ),
@@ -1113,7 +1114,8 @@ class DefaultAssetPickerBuilderDelegate
             child: Stack(
               children: <Widget>[
                 Positioned.fill(child: assetsGridBuilder(context)),
-                if (isPreviewEnabled || !isSingleAssetMode)
+                if (isPreviewEnabled || !isSingleAssetMode
+                || permissionNotifier.value == PermissionState.limited)
                   Positioned.fill(top: null, child: bottomActionBar(context)),
               ],
             ),


### PR DESCRIPTION
Fixes https://github.com/fluttercandies/flutter_wechat_assets_picker/issues/618

Before:
<img width="310" alt="Screenshot 2024-08-21 at 7 51 21 PM" src="https://github.com/user-attachments/assets/36570055-1979-4f17-98b8-bc75840f75c5">

After:
<img width="309" alt="Screenshot 2024-08-22 at 7 18 28 PM" src="https://github.com/user-attachments/assets/05c43d1e-cf7f-469a-9d0a-6104a0f35d2e">

