### PR TITLE
♻️ Make delegate respect generic types as much as possible

### DIFF
--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -207,10 +207,9 @@ class PickMethod {
                       return;
                     }
                     final picker = context.findAncestorWidgetOfExactType<
-                        AssetPicker<AssetEntity, AssetPathEntity>>()!;
-                    final builder =
-                        picker.builder as DefaultAssetPickerBuilderDelegate;
-                    final p = builder.provider;
+                        AssetPicker<AssetEntity, AssetPathEntity,
+                            DefaultAssetPickerBuilderDelegate>>()!;
+                    final p = picker.builder.provider;
                     await p.switchPath(
                       PathWrapper<AssetPathEntity>(
                         path:

--- a/example/lib/customs/pickers/directory_file_asset_picker.dart
+++ b/example/lib/customs/pickers/directory_file_asset_picker.dart
@@ -163,7 +163,11 @@ class _DirectoryFileAssetPickerState extends State<DirectoryFileAssetPicker> {
     return GestureDetector(
       onTap: isDisplayingDetail
           ? () async {
-              final Widget viewer = AssetPickerViewer<File, Directory>(
+              final viewer = AssetPickerViewer<
+                  File,
+                  Directory,
+                  FileAssetPickerViewerProvider,
+                  FileAssetPickerViewerBuilderDelegate>(
                 builder: FileAssetPickerViewerBuilderDelegate(
                   currentIndex: index,
                   previewAssets: fileList,
@@ -392,7 +396,11 @@ class FileAssetPickerBuilder
           Animation<double> animation,
           Animation<double> secondaryAnimation,
         ) {
-          return AssetPickerViewer<File, Directory>(
+          return AssetPickerViewer<
+              File,
+              Directory,
+              FileAssetPickerViewerProvider,
+              FileAssetPickerViewerBuilderDelegate>(
             builder: FileAssetPickerViewerBuilderDelegate(
               currentIndex:
                   index ?? provider.selectedAssets.indexOf(currentAsset),
@@ -418,7 +426,8 @@ class FileAssetPickerBuilder
     List<File>? selectedAssets,
     FileAssetPickerProvider? selectorProvider,
   }) async {
-    final Widget viewer = AssetPickerViewer<File, Directory>(
+    final viewer = AssetPickerViewer<File, Directory,
+        FileAssetPickerViewerProvider, FileAssetPickerViewerBuilderDelegate>(
       builder: FileAssetPickerViewerBuilderDelegate(
         currentIndex: index,
         previewAssets: previewAssets,
@@ -1210,17 +1219,18 @@ class FileAssetPickerViewerProvider extends AssetPickerViewerProvider<File> {
 }
 
 class FileAssetPickerViewerBuilderDelegate
-    extends AssetPickerViewerBuilderDelegate<File, Directory> {
+    extends AssetPickerViewerBuilderDelegate<File, Directory,
+        FileAssetPickerViewerProvider> {
   FileAssetPickerViewerBuilderDelegate({
     required super.previewAssets,
     required super.themeData,
     required super.currentIndex,
     super.selectedAssets,
-    super.selectorProvider,
+    this.selectorProvider,
     super.provider,
-  }) : super(
-          maxAssets: selectorProvider?.maxAssets,
-        );
+  }) : super(maxAssets: selectorProvider?.maxAssets);
+
+  final FileAssetPickerProvider? selectorProvider;
 
   late final PageController _pageController = PageController(
     initialPage: currentIndex,

--- a/example/lib/customs/pickers/insta_asset_picker.dart
+++ b/example/lib/customs/pickers/insta_asset_picker.dart
@@ -286,7 +286,8 @@ class _InstaAssetPickerState extends State<InstaAssetPicker> {
   }
 }
 
-class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
+class InstaAssetPickerBuilder<T extends DefaultAssetPickerProvider>
+    extends DefaultAssetPickerBuilderDelegate<T> {
   InstaAssetPickerBuilder({
     required super.provider,
     required super.initialPermission,
@@ -349,7 +350,7 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
   /// Initialize [_previewAsset] with [p.selectedAssets] if not empty
   /// otherwise if the first item of the album
   Future<void> _initializePreviewAsset(
-    DefaultAssetPickerProvider p,
+    T p,
     bool shouldDisplayAssets,
   ) async {
     if (_previewAsset.value != null) {
@@ -487,8 +488,8 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
             SizedBox(
           width: MediaQuery.sizeOf(context).width,
           height: previewHeight(context),
-          child: Selector<DefaultAssetPickerProvider, List<AssetEntity>>(
-            selector: (_, DefaultAssetPickerProvider p) => p.selectedAssets,
+          child: Selector<T, List<AssetEntity>>(
+            selector: (_, T p) => p.selectedAssets,
             builder: (_, List<AssetEntity> selected, __) {
               if (previewAsset == null && selected.isEmpty) {
                 return loadingIndicator(context);
@@ -502,7 +503,11 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
               final List<AssetEntity> assets =
                   selected.isEmpty ? <AssetEntity>[previewAsset!] : selected;
 
-              return AssetPickerViewer<AssetEntity, AssetPathEntity>(
+              return AssetPickerViewer<
+                  AssetEntity,
+                  AssetPathEntity,
+                  AssetPickerViewerProvider<AssetEntity>,
+                  InstaAssetPickerViewerBuilder>(
                 builder: InstaAssetPickerViewerBuilder(
                   currentIndex: effectiveIndex == -1 ? 0 : effectiveIndex,
                   previewAssets: assets,
@@ -541,7 +546,7 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
         _kPathSelectorRowHeight +
         MediaQuery.paddingOf(context).top;
 
-    return ChangeNotifierProvider<DefaultAssetPickerProvider>.value(
+    return ChangeNotifierProvider<T>.value(
       value: provider,
       builder: (BuildContext context, _) => ValueListenableBuilder<double>(
         valueListenable: _viewerPosition,
@@ -644,8 +649,8 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
 
   Widget _buildListAlbums(BuildContext context) {
     appBarPreferredSize ??= appBar(context).preferredSize;
-    return Consumer<DefaultAssetPickerProvider>(
-      builder: (BuildContext context, DefaultAssetPickerProvider provider, __) {
+    return Consumer<T>(
+      builder: (BuildContext context, T provider, __) {
         if (isAppleOS(context)) {
           return pathEntityListWidget(context);
         }
@@ -672,8 +677,8 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
 
   Widget _buildGrid(BuildContext context) {
     appBarPreferredSize ??= appBar(context).preferredSize;
-    return Consumer<DefaultAssetPickerProvider>(
-      builder: (BuildContext context, DefaultAssetPickerProvider p, __) {
+    return Consumer<T>(
+      builder: (BuildContext context, T p, __) {
         final bool shouldDisplayAssets =
             p.hasAssetsToDisplay || shouldBuildSpecialItem;
         _initializePreviewAsset(p, shouldDisplayAssets);

--- a/example/lib/customs/pickers/multi_tabs_assets_picker.dart
+++ b/example/lib/customs/pickers/multi_tabs_assets_picker.dart
@@ -279,7 +279,10 @@ class MultiTabAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
   late final TabController _tabController;
 
   @override
-  void initState(AssetPickerState<AssetEntity, AssetPathEntity> state) {
+  void initState(
+    AssetPickerState<AssetEntity, AssetPathEntity, MultiTabAssetPickerBuilder>
+        state,
+  ) {
     super.initState(state);
     _tabController = TabController(length: 3, vsync: state);
   }

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,0 +1,8 @@
+// Copyright 2019 The FlutterCandies author. All rights reserved.
+// Use of this source code is governed by an Apache license that can be found
+// in the LICENSE file.
+
+export 'src/widget/builder/asset_entity_grid_item_builder.dart';
+export 'src/widget/builder/audio_page_builder.dart';
+export 'src/widget/builder/image_page_builder.dart';
+export 'src/widget/builder/video_page_builder.dart';

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -121,14 +121,13 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   final LimitedPermissionOverlayPredicate? limitedPermissionOverlayPredicate;
 
   /// {@macro wechat_assets_picker.PathNameBuilder}
-  final PathNameBuilder<AssetPathEntity>? pathNameBuilder;
+  final PathNameBuilder<Path>? pathNameBuilder;
 
   /// {@macro wechat_assets_picker.AssetsChangeCallback}
-  final AssetsChangeCallback<AssetPathEntity>? assetsChangeCallback;
+  final AssetsChangeCallback<Path>? assetsChangeCallback;
 
   /// {@macro wechat_assets_picker.AssetsChangeRefreshPredicate}
-  final AssetsChangeRefreshPredicate<AssetPathEntity>?
-      assetsChangeRefreshPredicate;
+  final AssetsChangeRefreshPredicate<Path>? assetsChangeRefreshPredicate;
 
   /// [ThemeData] for the picker.
   /// 选择器使用的主题
@@ -229,7 +228,11 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   /// Keep a `initState` method to sync with [State].
   /// 保留一个 `initState` 方法与 [State] 同步。
   @mustCallSuper
-  void initState(AssetPickerState<Asset, Path> state) {}
+  void initState(
+    covariant AssetPickerState<Asset, Path,
+            AssetPickerBuilderDelegate<Asset, Path>>
+        state,
+  ) {}
 
   /// Keep a `dispose` method to sync with [State].
   /// 保留一个 `dispose` 方法与 [State] 同步。
@@ -395,11 +398,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
   /// Loading indicator.
   /// 加载指示器
   ///
-  /// Subclasses need to implement this due to the generic type limitation, and
-  /// not all delegates use [AssetPickerProvider].
-  ///
-  /// See also:
-  /// - [DefaultAssetPickerBuilderDelegate.loadingIndicator] as an example.
+  /// See [DefaultAssetPickerBuilderDelegate.loadingIndicator] as an example.
   Widget loadingIndicator(BuildContext context);
 
   /// GIF image type indicator.
@@ -1653,7 +1652,7 @@ class DefaultAssetPickerBuilderDelegate<T extends DefaultAssetPickerProvider>
     );
   }
 
-  /// It'll pop with [AssetPickerProvider.selectedAssets]
+  /// It'll pop with [T.selectedAssets]
   /// when there are any assets were chosen.
   /// 当有资源已选时，点击按钮将把已选资源通过路由返回。
   @override

--- a/lib/src/delegates/asset_picker_delegate.dart
+++ b/lib/src/delegates/asset_picker_delegate.dart
@@ -94,7 +94,8 @@ class AssetPickerDelegate {
       filterOptions: pickerConfig.filterOptions,
       initializeDelayDuration: route.transitionDuration,
     );
-    final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
+    final picker = AssetPicker<AssetEntity, AssetPathEntity,
+        DefaultAssetPickerBuilderDelegate>(
       key: key,
       permissionRequestOption: permissionRequestOption,
       builder: DefaultAssetPickerBuilderDelegate(
@@ -148,10 +149,13 @@ class AssetPickerDelegate {
   ///  * [AssetPickerBuilderDelegate] for how to customize/override widgets
   ///    during the picking process.
   /// {@endtemplate}
-  Future<List<Asset>?> pickAssetsWithDelegate<Asset, Path,
-      PickerProvider extends AssetPickerProvider<Asset, Path>>(
+  Future<List<Asset>?> pickAssetsWithDelegate<
+      Asset,
+      Path,
+      PickerProvider extends AssetPickerProvider<Asset, Path>,
+      Delegate extends AssetPickerBuilderDelegate<Asset, Path>>(
     BuildContext context, {
-    required AssetPickerBuilderDelegate<Asset, Path> delegate,
+    required Delegate delegate,
     PermissionRequestOption permissionRequestOption =
         const PermissionRequestOption(),
     Key? key,
@@ -159,15 +163,15 @@ class AssetPickerDelegate {
     AssetPickerPageRouteBuilder<List<Asset>>? pageRouteBuilder,
   }) async {
     await permissionCheck(requestOption: permissionRequestOption);
-    final Widget picker = AssetPicker<Asset, Path>(
+    final picker = AssetPicker<Asset, Path, Delegate>(
       key: key,
       permissionRequestOption: permissionRequestOption,
       builder: delegate,
     );
-    final List<Asset>? result = await Navigator.maybeOf(
+    final result = await Navigator.maybeOf(
       context,
       rootNavigator: useRootNavigator,
-    )?.push<List<Asset>>(
+    )?.push(
       pageRouteBuilder?.call(picker) ??
           AssetPickerPageRoute<List<Asset>>(builder: (_) => picker),
     );

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -421,35 +421,10 @@ class DefaultAssetPickerViewerBuilderDelegate
       (selectedAssets?.any((AssetEntity e) => e.type == AssetType.video) ??
           false);
 
-  @override
-  Widget assetPageBuilder(BuildContext context, int index) {
-    final AssetEntity asset = previewAssets.elementAt(
+  Widget assetSemanticsBuilder(BuildContext context, int index) {
+    final asset = previewAssets.elementAt(
       shouldReversePreview ? previewAssets.length - index - 1 : index,
     );
-    final Widget builder = switch (asset.type) {
-      AssetType.audio => AudioPageBuilder(
-          asset: asset,
-          shouldAutoplayPreview: shouldAutoplayPreview,
-        ),
-      AssetType.image => ImagePageBuilder(
-          asset: asset,
-          delegate: this,
-          previewThumbnailSize: previewThumbnailSize,
-          shouldAutoplayPreview: shouldAutoplayPreview,
-        ),
-      AssetType.video => VideoPageBuilder(
-          asset: asset,
-          delegate: this,
-          hasOnlyOneVideoAndMoment: isWeChatMoment && hasVideo,
-          shouldAutoplayPreview: shouldAutoplayPreview,
-        ),
-      AssetType.other => Center(
-          child: ScaleText(
-            textDelegate.unSupportedAssetType,
-            semanticsLabel: semanticsTextDelegate.unSupportedAssetType,
-          ),
-        ),
-    };
     return MergeSemantics(
       child: Consumer<AssetPickerViewerProvider<AssetEntity>?>(
         builder: (
@@ -476,12 +451,43 @@ class DefaultAssetPickerViewerBuilderDelegate
             hint: hint,
             image:
                 asset.type == AssetType.image || asset.type == AssetType.video,
-            child: w,
+            child: child,
           );
         },
-        child: builder,
+        child: assetPageBuilder(context, index),
       ),
     );
+  }
+
+  @override
+  Widget assetPageBuilder(BuildContext context, int index) {
+    final asset = previewAssets.elementAt(
+      shouldReversePreview ? previewAssets.length - index - 1 : index,
+    );
+    return switch (asset.type) {
+      AssetType.audio => AudioPageBuilder(
+          asset: asset,
+          shouldAutoplayPreview: shouldAutoplayPreview,
+        ),
+      AssetType.image => ImagePageBuilder(
+          asset: asset,
+          delegate: this,
+          previewThumbnailSize: previewThumbnailSize,
+          shouldAutoplayPreview: shouldAutoplayPreview,
+        ),
+      AssetType.video => VideoPageBuilder(
+          asset: asset,
+          delegate: this,
+          hasOnlyOneVideoAndMoment: isWeChatMoment && hasVideo,
+          shouldAutoplayPreview: shouldAutoplayPreview,
+        ),
+      AssetType.other => Center(
+          child: ScaleText(
+            textDelegate.unSupportedAssetType,
+            semanticsLabel: semanticsTextDelegate.unSupportedAssetType,
+          ),
+        ),
+    };
   }
 
   /// Preview item widgets for audios.
@@ -992,7 +998,7 @@ class DefaultAssetPickerViewerBuilderDelegate
             : const CustomBouncingScrollPhysics(),
         controller: pageController,
         itemCount: previewAssets.length,
-        itemBuilder: assetPageBuilder,
+        itemBuilder: assetSemanticsBuilder,
         onPageChanged: (int index) {
           currentIndex = index;
           pageStreamController.add(index);

--- a/lib/src/provider/asset_picker_viewer_provider.dart
+++ b/lib/src/provider/asset_picker_viewer_provider.dart
@@ -8,14 +8,14 @@ import '../constants/constants.dart';
 
 /// [ChangeNotifier] for assets picker viewer.
 /// 资源选择查看器的 provider model.
-class AssetPickerViewerProvider<A> extends ChangeNotifier {
-  /// Copy selected assets for editing when constructing.
-  /// 构造时深拷贝已选择的资源集合，用于后续编辑。
+class AssetPickerViewerProvider<Asset> extends ChangeNotifier {
   AssetPickerViewerProvider(
-    List<A>? assets, {
+    List<Asset>? assets, {
     this.maxAssets = defaultMaxAssetsCount,
   }) : assert(maxAssets > 0, 'maxAssets must be greater than 0.') {
-    _currentlySelectedAssets = (assets ?? <A>[]).toList();
+    // Copy selected assets for editing when constructing.
+    // 构造时深拷贝已选择的资源集合，用于后续编辑。
+    _currentlySelectedAssets = (assets ?? <Asset>[]).toList();
   }
 
   /// Maximum count for asset selection.
@@ -24,11 +24,11 @@ class AssetPickerViewerProvider<A> extends ChangeNotifier {
 
   /// Selected assets in the viewer.
   /// 查看器中已选择的资源
-  late List<A> _currentlySelectedAssets;
+  late List<Asset> _currentlySelectedAssets;
 
-  List<A> get currentlySelectedAssets => _currentlySelectedAssets;
+  List<Asset> get currentlySelectedAssets => _currentlySelectedAssets;
 
-  set currentlySelectedAssets(List<A> value) {
+  set currentlySelectedAssets(List<Asset> value) {
     if (value == _currentlySelectedAssets) {
       return;
     }
@@ -41,33 +41,33 @@ class AssetPickerViewerProvider<A> extends ChangeNotifier {
 
   /// Select asset.
   /// 选中资源
-  void selectAsset(A item) {
+  void selectAsset(Asset item) {
     if (currentlySelectedAssets.length == maxAssets ||
         currentlySelectedAssets.contains(item)) {
       return;
     }
-    final List<A> newList = _currentlySelectedAssets.toList()..add(item);
+    final List<Asset> newList = _currentlySelectedAssets.toList()..add(item);
     currentlySelectedAssets = newList;
   }
 
   /// Un-select asset.
   /// 取消选中资源
-  void unSelectAsset(A item) {
+  void unSelectAsset(Asset item) {
     if (currentlySelectedAssets.isEmpty ||
         !currentlySelectedAssets.contains(item)) {
       return;
     }
-    final List<A> newList = _currentlySelectedAssets.toList()..remove(item);
+    final List<Asset> newList = _currentlySelectedAssets.toList()..remove(item);
     currentlySelectedAssets = newList;
   }
 
   @Deprecated('Use selectAsset instead. This will be removed in 10.0.0')
-  void selectAssetEntity(A entity) {
+  void selectAssetEntity(Asset entity) {
     selectAsset(entity);
   }
 
   @Deprecated('Use unSelectAsset instead. This will be removed in 10.0.0')
-  void unselectAssetEntity(A entity) {
+  void unselectAssetEntity(Asset entity) {
     unSelectAsset(entity);
   }
 }

--- a/lib/src/widget/asset_picker.dart
+++ b/lib/src/widget/asset_picker.dart
@@ -18,7 +18,9 @@ import 'asset_picker_page_route.dart';
 
 AssetPickerDelegate _pickerDelegate = const AssetPickerDelegate();
 
-class AssetPicker<Asset, Path> extends StatefulWidget {
+class AssetPicker<Asset, Path,
+        Delegate extends AssetPickerBuilderDelegate<Asset, Path>>
+    extends StatefulWidget {
   const AssetPicker({
     super.key,
     required this.permissionRequestOption,
@@ -26,7 +28,7 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
   });
 
   final PermissionRequestOption permissionRequestOption;
-  final AssetPickerBuilderDelegate<Asset, Path> builder;
+  final Delegate builder;
 
   /// Provide another [AssetPickerDelegate] which override with
   /// custom methods during handling the picking,
@@ -66,17 +68,21 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
   }
 
   /// {@macro wechat_assets_picker.delegates.AssetPickerDelegate.pickAssetsWithDelegate}
-  static Future<List<Asset>?> pickAssetsWithDelegate<Asset, Path,
-      PickerProvider extends AssetPickerProvider<Asset, Path>>(
+  static Future<List<Asset>?> pickAssetsWithDelegate<
+      Asset,
+      Path,
+      PickerProvider extends AssetPickerProvider<Asset, Path>,
+      Delegate extends AssetPickerBuilderDelegate<Asset, Path>>(
     BuildContext context, {
-    required AssetPickerBuilderDelegate<Asset, Path> delegate,
+    required Delegate delegate,
     PermissionRequestOption permissionRequestOption =
         const PermissionRequestOption(),
     Key? key,
     AssetPickerPageRouteBuilder<List<Asset>>? pageRouteBuilder,
     bool useRootNavigator = true,
   }) {
-    return _pickerDelegate.pickAssetsWithDelegate<Asset, Path, PickerProvider>(
+    return _pickerDelegate
+        .pickAssetsWithDelegate<Asset, Path, PickerProvider, Delegate>(
       context,
       key: key,
       delegate: delegate,
@@ -102,11 +108,13 @@ class AssetPicker<Asset, Path> extends StatefulWidget {
   }
 
   @override
-  AssetPickerState<Asset, Path> createState() =>
-      AssetPickerState<Asset, Path>();
+  AssetPickerState<Asset, Path, Delegate> createState() =>
+      AssetPickerState<Asset, Path, Delegate>();
 }
 
-class AssetPickerState<Asset, Path> extends State<AssetPicker<Asset, Path>>
+class AssetPickerState<Asset, Path,
+        Delegate extends AssetPickerBuilderDelegate<Asset, Path>>
+    extends State<AssetPicker<Asset, Path, Delegate>>
     with TickerProviderStateMixin, WidgetsBindingObserver {
   Completer<PermissionState>? permissionStateLock;
 

--- a/lib/src/widget/builder/image_page_builder.dart
+++ b/lib/src/widget/builder/image_page_builder.dart
@@ -16,6 +16,7 @@ import 'package:wechat_picker_library/wechat_picker_library.dart';
 import '../../constants/constants.dart';
 import '../../delegates/asset_picker_text_delegate.dart';
 import '../../delegates/asset_picker_viewer_builder_delegate.dart';
+import '../../provider/asset_picker_viewer_provider.dart';
 
 class ImagePageBuilder extends StatefulWidget {
   const ImagePageBuilder({
@@ -30,7 +31,8 @@ class ImagePageBuilder extends StatefulWidget {
   /// 展示的资源
   final AssetEntity asset;
 
-  final AssetPickerViewerBuilderDelegate<AssetEntity, AssetPathEntity> delegate;
+  final AssetPickerViewerBuilderDelegate<AssetEntity, AssetPathEntity,
+      AssetPickerViewerProvider<AssetEntity>> delegate;
 
   final ThumbnailSize? previewThumbnailSize;
 

--- a/lib/src/widget/builder/video_page_builder.dart
+++ b/lib/src/widget/builder/video_page_builder.dart
@@ -12,6 +12,7 @@ import 'package:wechat_picker_library/wechat_picker_library.dart';
 import '../../constants/constants.dart';
 import '../../delegates/asset_picker_viewer_builder_delegate.dart';
 import '../../internals/singleton.dart';
+import '../../provider/asset_picker_viewer_provider.dart';
 
 class VideoPageBuilder extends StatefulWidget {
   const VideoPageBuilder({
@@ -26,7 +27,8 @@ class VideoPageBuilder extends StatefulWidget {
   /// 展示的资源
   final AssetEntity asset;
 
-  final AssetPickerViewerBuilderDelegate<AssetEntity, AssetPathEntity> delegate;
+  final AssetPickerViewerBuilderDelegate<AssetEntity, AssetPathEntity,
+      AssetPickerViewerProvider<AssetEntity>> delegate;
 
   /// Only previewing one video and with the [SpecialPickerType.wechatMoment].
   /// 是否处于 [SpecialPickerType.wechatMoment] 且只有一个视频

--- a/test/providers_test.dart
+++ b/test/providers_test.dart
@@ -23,15 +23,15 @@ void main() async {
       );
       await tester.tap(defaultButtonFinder);
       await tester.pumpAndSettle();
-      final Finder pickerFinder = find.byType(
-        AssetPicker<AssetEntity, AssetPathEntity>,
+      final picker = tester.widget<
+          AssetPicker<AssetEntity, AssetPathEntity,
+              DefaultAssetPickerBuilderDelegate>>(
+        find.byType(
+          AssetPicker<AssetEntity, AssetPathEntity,
+              DefaultAssetPickerBuilderDelegate>,
+        ),
       );
-      final AssetPicker<AssetEntity, AssetPathEntity> picker = tester.widget(
-        pickerFinder,
-      );
-      final DefaultAssetPickerProvider provider =
-          (picker.builder as DefaultAssetPickerBuilderDelegate).provider;
-      expect(provider, isA<DefaultAssetPickerProvider>());
+      final provider = picker.builder.provider;
       await tester.tap(find.widgetWithIcon(IconButton, Icons.close));
       await tester.pumpAndSettle();
       expect(

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -120,7 +120,8 @@ class TestAssetPickerDelegate extends AssetPickerDelegate {
       )
       ..hasAssetsToDisplay = true
       ..totalAssetsCount = 1;
-    final Widget picker = AssetPicker<AssetEntity, AssetPathEntity>(
+    final picker = AssetPicker<AssetEntity, AssetPathEntity,
+        DefaultAssetPickerBuilderDelegate>(
       key: key,
       permissionRequestOption: permissionRequestOption,
       builder: DefaultAssetPickerBuilderDelegate(


### PR DESCRIPTION
We have `Asset` and `Path` generic abstractions, but we didn't consider the delegate's generic abstractions. They are necessary when building delegates that rely on custom data source providers.

- [ ] Refactoring
- [ ] Migrations

FYI @LeGoffMael open for your ideas too.