### PR TITLE
implement SpecialPickerType.noSelection

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -268,6 +268,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Yotamho",
+      "name": "Yotam Hochman",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24762809?s=400&u=7e94b2cd1bd998e34794944e12247db4bff7214f&v=4",
+      "profile": "https://github.com/Yotamho",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/example/lib/customs/custom_picker_page.dart
+++ b/example/lib/customs/custom_picker_page.dart
@@ -3,6 +3,7 @@
 // in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:wechat_assets_picker_demo/customs/pickers/gallery_mode.dart';
 
 import '../constants/custom_pick_method.dart';
 import '../constants/extensions.dart';
@@ -61,6 +62,15 @@ class _CustomPickerPageState extends State<CustomPickersPage>
           MaterialPageRoute<void>(builder: (_) => const InstaAssetPicker()),
         ),
       ),
+      CustomPickMethod(
+        icon: '🖼️',
+        name: context.l10n.customPickerGalleryMode,
+        description: context.l10n.customPickerGalleryModeDescription,
+        method: (BuildContext context) =>
+            Navigator.maybeOf(context)?.push<void>(
+          MaterialPageRoute<void>(builder: (_) => const AssetsGallery()),
+        ),
+      )
     ];
   }
 

--- a/example/lib/customs/pickers/gallery_mode.dart
+++ b/example/lib/customs/pickers/gallery_mode.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+class AssetsGallery extends StatelessWidget {
+  const AssetsGallery({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final DefaultAssetPickerProvider provider =
+        DefaultAssetPickerProvider(requestType: RequestType.all);
+    final Future<PermissionState> ps = AssetPicker.permissionCheck(
+      requestOption: PermissionRequestOption(
+        androidPermission: AndroidPermission(
+          type: provider.requestType,
+          mediaLocation: false,
+        ),
+      ),
+    );
+
+    return FutureBuilder(
+      future: ps,
+      builder: (context, snapshot) => snapshot.hasData
+          ? DefaultAssetPickerBuilderDelegate(
+                  provider: provider,
+                  initialPermission: snapshot.data!,
+                  specialPickerType: SpecialPickerType.noSelection,
+                  locale: Localizations.maybeLocaleOf(context))
+              .build(context)
+          : const CircularProgressIndicator(),
+    );
+  }
+}

--- a/example/lib/l10n/app_en.arb
+++ b/example/lib/l10n/app_en.arb
@@ -54,5 +54,7 @@
   "customPickerMultiTabTab2": "Videos",
   "customPickerMultiTabTab3": "Images",
   "customPickerInstagramLayoutName": "Instagram layout picker",
-  "customPickerInstagramLayoutDescription": "The picker reproduces Instagram layout with preview and scroll animations. It's also published as the package insta_assets_picker."
+  "customPickerInstagramLayoutDescription": "The picker reproduces Instagram layout with preview and scroll animations. It's also published as the package insta_assets_picker.",
+  "customPickerGalleryMode": "Gallery mode",
+  "customPickerGalleryModeDescription": "Uses a widget that shows assets with ability to perform actions on them, but not to select and return them to calling widget."
 }

--- a/example/lib/l10n/app_zh.arb
+++ b/example/lib/l10n/app_zh.arb
@@ -54,5 +54,7 @@
   "customPickerMultiTabTab2": "视频",
   "customPickerMultiTabTab3": "图片",
   "customPickerInstagramLayoutName": "Instagram 布局的选择器",
-  "customPickerInstagramLayoutDescription": "该选择器以 Instagram 的布局模式构建，在选择时可以同时预览。其已发布为单独的 package：insta_assets_picker。"
+  "customPickerInstagramLayoutDescription": "该选择器以 Instagram 的布局模式构建，在选择时可以同时预览。其已发布为单独的 package：insta_assets_picker。",
+  "customPickerGalleryMode": "画廊模式",
+  "customPickerGalleryModeDescription": "使用一个小部件来显示能够对其执行操作的资产，但不能选择它们并将其返回到调用小部件。"
 }

--- a/example/lib/l10n/gen/app_localizations.dart
+++ b/example/lib/l10n/gen/app_localizations.dart
@@ -425,6 +425,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'The picker reproduces Instagram layout with preview and scroll animations. It\'s also published as the package insta_assets_picker.'**
   String get customPickerInstagramLayoutDescription;
+
+  /// No description provided for @customPickerGalleryMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Gallery mode'**
+  String get customPickerGalleryMode;
+
+  /// No description provided for @customPickerGalleryModeDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Uses a widget that shows assets with ability to perform actions on them, but not to select and return them to calling widget.'**
+  String get customPickerGalleryModeDescription;
 }
 
 class _AppLocalizationsDelegate

--- a/example/lib/l10n/gen/app_localizations_en.dart
+++ b/example/lib/l10n/gen/app_localizations_en.dart
@@ -192,4 +192,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get customPickerInstagramLayoutDescription =>
       'The picker reproduces Instagram layout with preview and scroll animations. It\'s also published as the package insta_assets_picker.';
+
+  @override
+  String get customPickerGalleryMode => 'Gallery mode';
+
+  @override
+  String get customPickerGalleryModeDescription =>
+      'Uses a widget that shows assets with ability to perform actions on them, but not to select and return them to calling widget.';
 }

--- a/example/lib/l10n/gen/app_localizations_zh.dart
+++ b/example/lib/l10n/gen/app_localizations_zh.dart
@@ -181,4 +181,11 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get customPickerInstagramLayoutDescription =>
       '该选择器以 Instagram 的布局模式构建，在选择时可以同时预览。其已发布为单独的 package：insta_assets_picker。';
+
+  @override
+  String get customPickerGalleryMode => '画廊模式';
+
+  @override
+  String get customPickerGalleryModeDescription =>
+      '使用一个小部件来显示能够对其执行操作的资产，但不能选择它们并将其返回到调用小部件。';
 }

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -25,6 +25,15 @@ enum SpecialPickerType {
   /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
   /// 而在单选模式下将直接返回点击的资源。
   noPreview,
+
+  /// Disable selection of assets.
+  /// No selection related widgets are shown, and assets can only be shown,
+  /// and allowing actions to be performed on assets by the user.
+  ///
+  /// 禁用资产选择。
+  /// 不显示与选择相关的小部件，只能显示资产，
+  /// 并允许用户对资产执行操作。
+  noSelection,
 }
 
 /// Provide an item slot for custom widget insertion.

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -804,10 +804,13 @@ class DefaultAssetPickerBuilderDelegate
   /// can be selected.
   /// * [SpecialPickerType.noPreview] Disable preview of asset; Clicking on an
   /// asset selects it.
+  /// * [SpecialPickerType.noSelection] Disable selection of assets; no select
+  /// indicator is shown.
   ///
   /// 这里包含一些特殊选择类型：
   /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。当用户选择了视频，将不能选择图片。
   /// * [SpecialPickerType.noPreview] 禁用资源预览。多选时单击资产将直接选中，单选时选中并返回。
+  /// * [SpecialPickerType.noSelection] 禁用资产选择。没有显示选择指示符。
   final SpecialPickerType? specialPickerType;
 
   /// Whether the picker should save the scroll offset between pushes and pops.
@@ -830,6 +833,9 @@ class DefaultAssetPickerBuilderDelegate
   /// 当前是否为微信朋友圈选择模式
   bool get isWeChatMoment =>
       specialPickerType == SpecialPickerType.wechatMoment;
+
+  /// Whether the [SpecialPickerType.noSelection] is enabled.
+  bool get isNoSelection => specialPickerType == SpecialPickerType.noSelection;
 
   /// Whether the preview of assets is enabled.
   /// 资源的预览是否启用
@@ -1447,12 +1453,14 @@ class DefaultAssetPickerBuilderDelegate
       AssetType.audio => audioItemBuilder(context, currentIndex, asset),
       AssetType.other => const SizedBox.shrink(),
     };
+
     final Widget content = Stack(
       key: ValueKey<String>(asset.id),
       children: <Widget>[
         builder,
         selectedBackdrop(context, currentIndex, asset),
-        if (!isWeChatMoment || asset.type != AssetType.video)
+        if ((!isWeChatMoment || asset.type != AssetType.video) &&
+            !isNoSelection)
           selectIndicator(context, index, asset),
         itemBannedIndicator(context, asset),
       ],

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -759,7 +759,8 @@ class DefaultAssetPickerViewerBuilderDelegate
             )
           : null,
       actions: [
-        if (provider != null)
+        if (provider != null &&
+            specialPickerType != SpecialPickerType.noSelection)
           Semantics(
             sortKey: ordinalSortKey(0.2),
             child: selectButton(context),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,7 +4,9 @@
 //
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wechat_assets_picker/src/internals/singleton.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
 import 'test_utils.dart';
@@ -98,6 +100,39 @@ void main() {
         await tester.pumpAndSettle();
         expect(
           find.text(const AssetPickerTextDelegate().confirm),
+          findsNothing,
+        );
+      });
+    });
+    group('when disabled selection', () {
+      testWidgets('selection is not possible in asset picker',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          defaultPickerTestApp(
+            onButtonPressed: (BuildContext context) {
+              AssetPicker.pickAssets(
+                context,
+                pickerConfig: const AssetPickerConfig(
+                  specialPickerType: SpecialPickerType.noSelection,
+                ),
+              );
+            },
+          ),
+        );
+        await tester.tap(defaultButtonFinder);
+        await tester.pumpAndSettle();
+        expect(
+          find.byWidgetPredicate((w) =>
+              w is AnimatedContainer &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle),
+          findsNothing,
+        );
+        await tester.tap(find.byWidgetPredicate(
+            (w) => w is Semantics && w.properties.sortKey?.name == 'GridItem'));
+        await tester.pumpAndSettle();
+        expect(
+          find.bySemanticsLabel(
+              Singleton.textDelegate.semanticsTextDelegate.select),
           findsNothing,
         );
       });


### PR DESCRIPTION
# implement SpecialPickerType.noSelection
## Motivation
"No Selection Mode" is meant for use cases when the user of the library does not need to implement asset picking, but just a view of the assets.
The concept alone may be questionable, but this work will be succeeded by allowing the user of the library to add custom actions per asset (like sharing button, or saving asset-ID).
The feature is implemented separately for the sake of modular development. 

## Effect
`SpecialPickerType.noSelection` disables the selection buttons from the grid view and from the asset view.