### PR TITLE
Drag Select Special Option for Asset Picker

### DIFF
--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -329,6 +329,24 @@ class PickMethod {
     );
   }
 
+    factory PickMethod.dragSelect(BuildContext context, int maxAssetsCount) {
+    return PickMethod(
+      icon: '📲',
+      name: context.l10n.pickMethodDragSelectName,
+      description: context.l10n.pickMethodDragSelectDescription,
+      method: (BuildContext context, List<AssetEntity> assets) {
+        return AssetPicker.pickAssets(
+          context,
+          pickerConfig: AssetPickerConfig(
+            maxAssets: maxAssetsCount,
+            selectedAssets: assets,
+            specialPickerType: SpecialPickerType.dragSelect,
+          ),
+        );
+      },
+    );
+  }
+
   factory PickMethod.keepScrollOffset({
     required BuildContext context,
     required DefaultAssetPickerBuilderDelegate Function() delegate,

--- a/example/lib/constants/picker_method.dart
+++ b/example/lib/constants/picker_method.dart
@@ -329,7 +329,7 @@ class PickMethod {
     );
   }
 
-    factory PickMethod.dragSelect(BuildContext context, int maxAssetsCount) {
+  factory PickMethod.dragSelect(BuildContext context, int maxAssetsCount) {
     return PickMethod(
       icon: '📲',
       name: context.l10n.pickMethodDragSelectName,

--- a/example/lib/l10n/app_en.arb
+++ b/example/lib/l10n/app_en.arb
@@ -30,6 +30,8 @@
   "pickMethodPrependItemDescription": "A special item will prepend to the assets grid.",
   "pickMethodNoPreviewName": "No preview",
   "pickMethodNoPreviewDescription": "You cannot preview assets during the picking, the behavior is like the WhatsApp/MegaTok pattern.",
+  "pickMethodDragSelectName": "Drag Select",
+  "pickMethodDragSelectDescription": "You can drag and select assets in this mode.",
   "pickMethodKeepScrollOffsetName": "Keep scroll offset",
   "pickMethodKeepScrollOffsetDescription": "Pick assets from same scroll position.",
   "pickMethodChangeLanguagesName": "Change Languages",

--- a/example/lib/l10n/app_zh.arb
+++ b/example/lib/l10n/app_zh.arb
@@ -30,6 +30,8 @@
   "pickMethodPrependItemDescription": "网格的靠前位置会添加一个自定义的 widget。",
   "pickMethodNoPreviewName": "禁止预览",
   "pickMethodNoPreviewDescription": "无法预览选择的资源，与 WhatsApp/MegaTok 的行为类似。",
+  "pickMethodDragSelectName": "拖动选择",
+  "pickMethodDragSelectDescription": "您可以在此模式下拖动并选择资源。",
   "pickMethodKeepScrollOffsetName": "保持滚动位置",
   "pickMethodKeepScrollOffsetDescription": "可以从上次滚动到的位置再次开始选择。",
   "pickMethodChangeLanguagesName": "更改语言",

--- a/example/lib/l10n/gen/app_localizations.dart
+++ b/example/lib/l10n/gen/app_localizations.dart
@@ -8,6 +8,8 @@ import 'package:intl/intl.dart' as intl;
 import 'app_localizations_en.dart';
 import 'app_localizations_zh.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of AppLocalizations
 /// returned by `AppLocalizations.of(context)`.
 ///
@@ -275,6 +277,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You cannot preview assets during the picking, the behavior is like the WhatsApp/MegaTok pattern.'**
   String get pickMethodNoPreviewDescription;
+
+  /// No description provided for @pickMethodDragSelectName.
+  ///
+  /// In en, this message translates to:
+  /// **'Drag Select'**
+  String get pickMethodDragSelectName;
+
+  /// No description provided for @pickMethodDragSelectDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'You can drag and select assets in this mode.'**
+  String get pickMethodDragSelectDescription;
 
   /// No description provided for @pickMethodKeepScrollOffsetName.
   ///

--- a/example/lib/l10n/gen/app_localizations_en.dart
+++ b/example/lib/l10n/gen/app_localizations_en.dart
@@ -1,5 +1,7 @@
 import 'app_localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
@@ -105,6 +107,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get pickMethodNoPreviewDescription =>
       'You cannot preview assets during the picking, the behavior is like the WhatsApp/MegaTok pattern.';
+
+  @override
+  String get pickMethodDragSelectName => 'Drag Select';
+
+  @override
+  String get pickMethodDragSelectDescription =>
+      'You can drag and select assets in this mode.';
 
   @override
   String get pickMethodKeepScrollOffsetName => 'Keep scroll offset';

--- a/example/lib/l10n/gen/app_localizations_zh.dart
+++ b/example/lib/l10n/gen/app_localizations_zh.dart
@@ -1,5 +1,7 @@
 import 'app_localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Chinese (`zh`).
 class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
@@ -99,6 +101,12 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get pickMethodNoPreviewDescription =>
       '无法预览选择的资源，与 WhatsApp/MegaTok 的行为类似。';
+
+  @override
+  String get pickMethodDragSelectName => '拖动选择';
+
+  @override
+  String get pickMethodDragSelectDescription => '您可以在此模式下拖动并选择资源。';
 
   @override
   String get pickMethodKeepScrollOffsetName => '保持滚动位置';

--- a/example/lib/pages/multi_assets_page.dart
+++ b/example/lib/pages/multi_assets_page.dart
@@ -61,6 +61,7 @@ class _MultiAssetsPageState extends State<MultiAssetsPage>
         },
       ),
       PickMethod.noPreview(context, maxAssetsCount),
+      PickMethod.dragSelect(context, maxAssetsCount),
       PickMethod.customizableTheme(context, maxAssetsCount),
       PickMethod.pathNameBuilder(context, maxAssetsCount),
       PickMethod.customFilterOptions(context, maxAssetsCount),

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -119,12 +119,16 @@ class AssetPickerConfig {
   ///   no more images can be selected.
   /// * [SpecialPickerType.noPreview] Disable preview of asset;
   ///   Clicking on an asset selects it.
+  /// * [SpecialPickerType.dragSelect] User able to drag
+  ///   and select assets.
   ///
   /// 这里包含一些特殊选择类型：
   /// * [SpecialPickerType.wechatMoment] 微信朋友圈模式。
   ///   当用户选择了视频，将不能选择图片。
   /// * [SpecialPickerType.noPreview] 禁用资源预览。
   ///   多选时单击资产将直接选中，单选时选中并返回。
+  /// * [SpecialPickerType.dragSelect] 用户可以拖动
+  /// 并选择资产。
   final SpecialPickerType? specialPickerType;
 
   /// Whether the picker should save the scroll offset between pushes and pops.

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -29,13 +29,10 @@ enum SpecialPickerType {
   /// Drag and Select.
   /// 禁用资源预览
   ///
-  /// There is no preview mode when clicking grid items.
-  /// In multiple select mode, any click (either on the select indicator or on
-  /// the asset itself) will select the asset.
-  /// In single select mode, any click directly selects the asset and returns.
-  /// 用户在点击网格的 item 时无法进入预览。
-  /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
-  /// 而在单选模式下将直接返回点击的资源。
+  /// The user can drag and select items. Must be in multiple select mode.
+  /// Triggers all the settings of preview mode plus drag and select.
+  /// 用户可以拖动并选择项目。必须处于多选模式
+  /// 触发预览模式的所有设置以及拖动和选择。
   dragSelect,
 }
 

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -25,6 +25,18 @@ enum SpecialPickerType {
   /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
   /// 而在单选模式下将直接返回点击的资源。
   noPreview,
+
+  /// Drag and Select.
+  /// 禁用资源预览
+  ///
+  /// There is no preview mode when clicking grid items.
+  /// In multiple select mode, any click (either on the select indicator or on
+  /// the asset itself) will select the asset.
+  /// In single select mode, any click directly selects the asset and returns.
+  /// 用户在点击网格的 item 时无法进入预览。
+  /// 在多选模式下无论点击选择指示还是 item 都将触发选择，
+  /// 而在单选模式下将直接返回点击的资源。
+  dragSelect,
 }
 
 /// Provide an item slot for custom widget insertion.

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1276,9 +1276,7 @@ class DefaultAssetPickerBuilderDelegate
 
         final textDirection = Directionality.of(context);
         Widget sliverGrid(BuildContext context, List<AssetEntity> assets) {
-          return SliverToBoxAdapter(
-            child: Column(
-              children: [
+          return 
                 DragSelectGridView(
                   gridScrollController: gridScrollController,
                   autoScrollHotspotHeight: 150,
@@ -1318,10 +1316,7 @@ class DefaultAssetPickerBuilderDelegate
                     crossAxisSpacing: 2,
                     mainAxisSpacing: 2,
                   ),
-                )
-              ]
-            )
-          );
+                );
         }
 
         return LayoutBuilder(
@@ -1362,7 +1357,9 @@ class DefaultAssetPickerBuilderDelegate
                       context.bottomPadding + bottomSectionHeight,
                     );
                     appBarPreferredSize ??= appBar(context).preferredSize;
-                    return CustomScrollView(
+                    return sliverGrid(context, assets);
+                    
+                    /*CustomScrollView(
                       physics: const AlwaysScrollableScrollPhysics(),
                       controller: gridScrollController,
                       anchor: gridRevert ? anchor : 0,
@@ -1382,7 +1379,7 @@ class DefaultAssetPickerBuilderDelegate
                           ),
                         if (isAppleOS(context) && !gridRevert) bottomGap,
                       ],
-                    );
+                    );*/
                   },
                 ),
               ),

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1276,9 +1276,7 @@ class DefaultAssetPickerBuilderDelegate
 
         final textDirection = Directionality.of(context);
         Widget sliverGrid(BuildContext context, List<AssetEntity> assets) {
-          return 
-                DragSelectGridView(
-                  gridScrollController: gridScrollController,
+          return DragSelectGridView(
                   autoScrollHotspotHeight: 150,
                   itemBuilder: (BuildContext context, int index, bool selected) {
                     Widget c = MergeSemantics(
@@ -2520,36 +2518,16 @@ class SelectableItem extends StatefulWidget {
 
 class _SelectableItemState extends State<SelectableItem>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _controller;
-  late final Animation<double> _scaleAnimation;
 
   @override
   void initState() {
     super.initState();
-
-    _controller = AnimationController(
-      value: widget.selected ? 1 : 0,
-      duration: kThemeChangeDuration,
-      vsync: this,
-    );
-
-    _scaleAnimation = Tween<double>(begin: 1, end: 0.8).animate(
-      CurvedAnimation(
-        parent: _controller,
-        curve: Curves.ease,
-      ),
-    );
   }
 
   @override
   void didUpdateWidget(SelectableItem oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.selected != widget.selected) {
-      if (widget.selected) {
-        //_controller.forward();
-      } else {
-        //_controller.reverse();
-      }
       widget.parent.selectAsset(widget.context, widget.asset, widget.index, oldWidget.selected);
       setState((){});
     }
@@ -2557,37 +2535,13 @@ class _SelectableItemState extends State<SelectableItem>
 
   @override
   void dispose() {
-    _controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: _scaleAnimation,
-      builder: (context, child) {
-        return Container(
-          child: Transform.scale(
-            scale: _scaleAnimation.value,
-            child: DecoratedBox(
-              child: child,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(2),
-                color: calculateColor(),
-              ),
-            ),
-          ),
-        );
-      },
+    return Container(
       child: widget.child
-    );
-  }
-
-  Color? calculateColor() {
-    return Color.lerp(
-      widget.color.shade500,
-      widget.color.shade900,
-      _controller.value,
     );
   }
 }

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1748,6 +1748,7 @@ class DefaultAssetPickerBuilderDelegate
           onPressed: shouldAllowConfirm
               ? () {
                   Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
+                  Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
                 }
               : null,
           materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -616,6 +616,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       child: IconButton(
         onPressed: () {
           Navigator.maybeOf(context)?.maybePop();
+          Navigator.maybeOf(context)?.maybePop();
         },
         tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
         icon: Icon(
@@ -640,6 +641,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       alignment: AlignmentDirectional.centerStart,
       child: IconButton(
         onPressed: () {
+          Navigator.maybeOf(context)?.maybePop();
           Navigator.maybeOf(context)?.maybePop();
         },
         icon: const Icon(Icons.close),
@@ -888,6 +890,7 @@ class DefaultAssetPickerBuilderDelegate
     }
     provider.selectAsset(asset);
     if (isSingleAssetMode && !isPreviewEnabled) {
+      Navigator.maybeOf(context)?.maybePop(provider.selectedAssets);
       Navigator.maybeOf(context)?.maybePop(provider.selectedAssets);
     }
   }
@@ -1277,6 +1280,7 @@ class DefaultAssetPickerBuilderDelegate
             child: Column(
               children: [
                 DragSelectGridView(
+                  autoScrollHotspotHeight: 150,
                   itemBuilder: (BuildContext context, int index, bool selected) {
                     Widget c = MergeSemantics(
                       child: Directionality(
@@ -1308,10 +1312,10 @@ class DefaultAssetPickerBuilderDelegate
                   shrinkWrap: true,
                   // Explicitly disable semantic indexes for custom usage.
                   addSemanticIndexes: false,
-                  gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                    maxCrossAxisExtent: 150,
-                    crossAxisSpacing: 8,
-                    mainAxisSpacing: 8,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: gridCount,
+                    crossAxisSpacing: 2,
+                    mainAxisSpacing: 2,
                   ),
                 )
               ]
@@ -1678,6 +1682,7 @@ class DefaultAssetPickerBuilderDelegate
           ),
           onPressed: shouldAllowConfirm
               ? () {
+                  Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
                   Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
                 }
               : null,

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1280,6 +1280,7 @@ class DefaultAssetPickerBuilderDelegate
             child: Column(
               children: [
                 DragSelectGridView(
+                  gridScrollController: gridScrollController,
                   autoScrollHotspotHeight: 150,
                   itemBuilder: (BuildContext context, int index, bool selected) {
                     Widget c = MergeSemantics(

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -616,6 +616,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       child: IconButton(
         onPressed: () {
           Navigator.maybeOf(context)?.maybePop();
+          Navigator.maybeOf(context)?.maybePop();
         },
         tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
         icon: Icon(
@@ -640,6 +641,7 @@ abstract class AssetPickerBuilderDelegate<Asset, Path> {
       alignment: AlignmentDirectional.centerStart,
       child: IconButton(
         onPressed: () {
+          Navigator.maybeOf(context)?.maybePop();
           Navigator.maybeOf(context)?.maybePop();
         },
         icon: const Icon(Icons.close),
@@ -888,6 +890,7 @@ class DefaultAssetPickerBuilderDelegate
     }
     provider.selectAsset(asset);
     if (isSingleAssetMode && !isPreviewEnabled) {
+      Navigator.maybeOf(context)?.maybePop(provider.selectedAssets);
       Navigator.maybeOf(context)?.maybePop(provider.selectedAssets);
     }
   }
@@ -1276,7 +1279,6 @@ class DefaultAssetPickerBuilderDelegate
           return SliverToBoxAdapter(
             child: Column(
               children: [
-<<<<<<< HEAD
                 DragSelectGridView(
                   gridScrollController: gridScrollController,
                   autoScrollHotspotHeight: 150,
@@ -1289,50 +1291,33 @@ class DefaultAssetPickerBuilderDelegate
                           index,
                           assets,
                           specialItem: specialItem,
-=======
-                DragSelectHolder(
-                  // https://stackoverflow.com/questions/52000130/flutter-get-local-position-of-gesture-detector
-                  // https://www.google.com/search?q=geusterdetector+flutter+local+position+is+relative+to+grid+not+screen&oq=geusterdetector+flutter+local+position+is+relative+to+grid+not+screen&gs_lcrp=EgZjaHJvbWUyBggAEEUYOdIBCTE4MTIxajBqMagCALACAA&sourceid=chrome&ie=UTF-8
-                  dragSelectView: 
-                    DragSelectGridView(
-                    itemBuilder: (BuildContext context, int index, bool selected) {
-                      Widget c = MergeSemantics(
-                        child: Directionality(
-                          textDirection: textDirection,
-                          child: assetGridItemBuilder(
-                            context,
-                            index,
-                            assets,
-                            specialItem: specialItem,
-                          ),
->>>>>>> refs/remotes/origin/main
                         ),
-                      );
-                      return SelectableItem(
-                        index: index,
-                        color: Colors.blue,
-                        selected: selected,
-                        child: c,
-                        asset: assets[index],
-                        parent: this,
-                        context: context
-                      );
-                    },
-                    itemCount: assetsGridItemCount(
-                      context: context,
-                      assets: assets,
-                      placeholderCount: placeholderCount,
-                      specialItem: specialItem,
-                    ),
-                    shrinkWrap: true,
-                    // Explicitly disable semantic indexes for custom usage.
-                    addSemanticIndexes: false,
-                    gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                      maxCrossAxisExtent: 150,
-                      crossAxisSpacing: 8,
-                      mainAxisSpacing: 8,
-                    ),
-                  )
+                      ),
+                    );
+                    return SelectableItem(
+                      index: index,
+                      color: Colors.blue,
+                      selected: selected,
+                      child: c,
+                      asset: assets[index],
+                      parent: this,
+                      context: context
+                    );
+                  },
+                  itemCount: assetsGridItemCount(
+                    context: context,
+                    assets: assets,
+                    placeholderCount: placeholderCount,
+                    specialItem: specialItem,
+                  ),
+                  shrinkWrap: true,
+                  // Explicitly disable semantic indexes for custom usage.
+                  addSemanticIndexes: false,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: gridCount,
+                    crossAxisSpacing: 2,
+                    mainAxisSpacing: 2,
+                  ),
                 )
               ]
             )
@@ -1407,19 +1392,6 @@ class DefaultAssetPickerBuilderDelegate
       },
     );
   }
-
-
-
-
-
-
-
-
-
-
-
-
-
 
   /// There are several conditions within this builder:
   ///  * Return item builder according to the asset's type.
@@ -1711,6 +1683,7 @@ class DefaultAssetPickerBuilderDelegate
           ),
           onPressed: shouldAllowConfirm
               ? () {
+                  Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
                   Navigator.maybeOf(context)?.maybePop(p.selectedAssets);
                 }
               : null,
@@ -2510,28 +2483,6 @@ class DefaultAssetPickerBuilderDelegate
 
 
 
-
-
-
-class DragSelectHolder extends StatelessWidget {
-  DragSelectGridView dragSelectView;
-
-  DragSelectHolder({
-    required this.dragSelectView
-  });
-
- @override
- Widget build(BuildContext context) {
-   return /*SizedBox(
-    width: context.size?.width,
-    height: context.size?.height,
-    child: Scaffold(
-      body:
-      */dragSelectView;
-    /*)
-   );*/
- }
-}
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   provider: ^6.0.5
   video_player: ^2.7.0
   visibility_detector: ^0.4.0
+  drag_select_grid_view: ^0.6.2
 
 dev_dependencies:
   flutter_lints: any


### PR DESCRIPTION
In these commits there is a new drag and select feature that is available as a special option, just as no-preview is one of these options. There is also auto scroll when the user moves their finger/stylus too close to the bottom or top, it scrolls for them so they can keep selecting as it scrolls. It takes advantage of the [drag_select_grid_view](https://pub.dev/packages/drag_select_grid_view) library.

The demo in this repo is also updated to have a drag select example. 

I think drag and select is a very useful feature to have, so users can select a large number of items in a short time, and don't have to bother to select each item on an individual basis.

Please pardon my Chinese. I know it probably isn't perfect.

This is already done in a different pull request, well done to them: https://github.com/fluttercandies/flutter_wechat_assets_picker/pull/465. They did it in much less lines of code. Maybe ours could be combined somehow.

I am happy to change anything that needs to be changed.