### PR TITLE
⚡️ Order by modified date by default to align WeChat behavior

### DIFF
--- a/lib/src/provider/asset_picker_provider.dart
+++ b/lib/src/provider/asset_picker_provider.dart
@@ -337,7 +337,8 @@ class DefaultAssetPickerProvider
     final fog = filterOptions;
     if (fog == null) {
       options = AdvancedCustomFilter(
-        orderBy: [OrderByItem.desc(CustomColumns.base.createDate)],
+        // Same as WeChat.
+        orderBy: [OrderByItem.desc(CustomColumns.base.modifiedDate)],
       );
     } else if (fog is FilterOptionGroup) {
       final newOptions = FilterOptionGroup(


### PR DESCRIPTION
100% sure that WeChat is using the modified date when sorting assets.

This would be a behavior-breaking change, so delay it to v10.