### PR TITLE
支持业务 App 页面浏览的埋点述求

### DIFF
--- a/lib/src/widget/asset_picker_page_route.dart
+++ b/lib/src/widget/asset_picker_page_route.dart
@@ -23,6 +23,7 @@ class AssetPickerPageRoute<T> extends PageRoute<T> {
     this.maintainState = true,
     this.opaque = true,
     this.canTransitionFromPredicate,
+    super.settings,
   });
 
   final WidgetBuilder builder;


### PR DESCRIPTION
在 AssetPickerPageRoute 构造函数中添加 super.settings 配置，以便于通过 NavigatorObserver 采集页面浏览时，能够正确拿到 RouteSettings