### PR TITLE
🐛 Fix `selectPredicate` not being called when selecting the video asset under the WeChat Moment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ that can be found in the LICENSE file. -->
 **Fixes**
 
 - Fix semantics with the close button.
+- Fix `selectPredicate` not being called when selecting the video asset under the WeChat Moment mode.
 
 ## 9.5.1
 

--- a/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_viewer_builder_delegate.dart
@@ -793,13 +793,17 @@ class DefaultAssetPickerViewerBuilderDelegate
           );
           Future<void> onPressed() async {
             if (isWeChatMoment && hasVideo) {
-              Navigator.maybeOf(context)?.pop(<AssetEntity>[currentAsset]);
+              if (await onChangingSelected(context, currentAsset, false)) {
+                Navigator.maybeOf(context)?.pop(<AssetEntity>[currentAsset]);
+              }
               return;
             }
+
             if (provider!.isSelectedNotEmpty) {
               Navigator.maybeOf(context)?.pop(provider.currentlySelectedAssets);
               return;
             }
+
             if (await onChangingSelected(context, currentAsset, false)) {
               Navigator.maybeOf(context)?.pop(
                 selectedAssets ?? <AssetEntity>[currentAsset],


### PR DESCRIPTION
Fixes #707.