### PR TITLE
Improve the preview selection logic

### DIFF
--- a/lib/src/provider/asset_picker_viewer_provider.dart
+++ b/lib/src/provider/asset_picker_viewer_provider.dart
@@ -42,7 +42,7 @@ class AssetPickerViewerProvider<Asset> extends ChangeNotifier {
   /// Select asset.
   /// 选中资源
   void selectAsset(Asset item) {
-    if (currentlySelectedAssets.length == maxAssets ||
+    if (currentlySelectedAssets.length >= maxAssets ||
         currentlySelectedAssets.contains(item)) {
       return;
     }


### PR DESCRIPTION
---
name: Bug fix and feature improve
about: Improve the preview selection logic 
title: "Improve the preview selection logic"
labels: feature, await investigate
---

**Version information**
 - Device: Xiaomi15
 - OS: HyperOS 3.0.7.0
 - Package Version: v10.1.0
 - Flutter Version: v3.38.5

**Is your feature request related to a problem?**
maxAssets is set to 1.
After selecting an asset in the selection screen, it is still possible to select another asset in the preview screen, and the newly selected asset is added to the bottom selected-assets list.

This leads to the following issues:
	1.	When the previously selected asset is deselected and the later selected asset is selected, the bottom selected-assets list shows two items as selected at the same time, even though they actually refer to the same asset.
	2.	After closing the preview screen, if the currently selected asset is deselected, another asset is automatically selected by default, resulting in a selection state that does not match user expectations.

**Describe the solution you'd like**
- When entering the preview screen by tapping Preview, disable the selection feature and keep preview-only functionality.
- When entering the preview screen by tapping an asset item, display the selection button based on the current selection count and whether the previewed item is already selected. Avoid showing items as selectable when the maximum selection limit has been reached, even though tapping them has no effect, as this can confuse users.

**Additional context**
![5745648eba360808a956359735d88f52](https://github.com/user-attachments/assets/d051f252-6c44-464f-877b-2a1028df42ec)
![35a82f49be791a20724a1f1d38416598](https://github.com/user-attachments/assets/3f8ca11c-4109-4035-8287-05d4be5de2c5)

