### PR TITLE
Add READ_MEDIA_VISUAL_USER_SELECTED permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,15 @@ Otherwise, no assets can be fetched on Android 13.
 
 #### Permissions
 
-| Name                     | Required | Declared | Max API Level | Others                       |
-|--------------------------|----------|----------|---------------|------------------------------|
-| `READ_EXTERNAL_STORAGE`  | YES      | YES      | 32            |                              |
-| `WRITE_EXTERNAL_STORAGE` | NO       | NO       | 29            |                              |
-| `ACCESS_MEDIA_LOCATION`  | YES*     | NO       | N/A           | Required when reading EXIF   |
-| `READ_MEDIA_IMAGES`      | YES*     | YES      | N/A           | Required when reading images | 
-| `READ_MEDIA_VIDEO`       | YES*     | YES      | N/A           | Required when reading videos | 
-| `READ_MEDIA_AUDIO`       | YES*     | YES      | N/A           | Required when reading audios | 
+| Name                              | Required | Declared | Max API Level | Others                              |
+|-----------------------------------|----------|----------|---------------|-------------------------------------|
+| `READ_EXTERNAL_STORAGE`           | YES      | YES      | 32            |                                     |
+| `WRITE_EXTERNAL_STORAGE`          | NO       | NO       | 29            |                                     |
+| `ACCESS_MEDIA_LOCATION`           | YES*     | NO       | N/A           | Required when reading EXIF          |
+| `READ_MEDIA_IMAGES`               | YES*     | YES      | N/A           | Required when reading images        | 
+| `READ_MEDIA_VIDEO`                | YES*     | YES      | N/A           | Required when reading videos        | 
+| `READ_MEDIA_AUDIO`                | YES*     | YES      | N/A           | Required when reading audios        | 
+| `READ_MEDIA_VISUAL_USER_SELECTED` | YES*     | YES      | 34            | Required when reading user selected |
 
 If you're targeting Android SDK 33+,
 and you don't need to load photos, videos or audios,
@@ -212,6 +213,8 @@ consider declare only relevant permission in your apps, more specifically:
     <!--Requesting access to images and videos.-->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <!--Requesting access to limited images by user selection when prompting permission.-->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <!--When your app has no need to access audio, remove it or comment it out.-->
     <!--<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />-->
 </manifest>


### PR DESCRIPTION
###  Description

This PR fixes an issue where `permissionCheck()` returns an inaccurate status (`isAuth = true` and `isLimited = false`) after the user has already granted **Limited Photo Access**.

It also fixes 

###  The Problem

When a user selects "Limited Access" for the first time:
1. The system correctly grants limited access.
2. However, subsequent calls to `AssetPicker.permissionCheck()` incorrectly return `isAuth = true` and `isLimited = false`.

**Code Example of the Issue:**
```dart
final ps = await AssetPicker.permissionCheck();
// Incorrect behavior: isAuth is true and isLimited is false after limited access was granted
debugPrint('isAuth =  $ {ps.isAuth}, isLimited =  $ {ps.isLimited}'); 
```

### Consequences

- The permission status is misleading.
- Using specialItems to request changes to permitted images fails to update the picker options because the library thinks permission is denied.

### The Fix

Updated the docs to add `READ_MEDIA_VISUAL_USER_SELECTED` permission for developers.