### PR TITLE
fix(a11y): make assetGridItemSemanticIndex 1-based to match previous behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ that can be found in the LICENSE file. -->
 
 ## Unreleased
 
-*None.*
+**Fixes**
+
+- Fix `assetGridItemSemanticIndex` returning a 0-based index, causing screen readers to announce assets as "Image 0, Image 1, ..." instead of "Image 1, Image 2, ...".
 
 ## 10.1.1
 

--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -1675,7 +1675,7 @@ class DefaultAssetPickerBuilderDelegate<T extends DefaultAssetPickerProvider>
     final prependItems = specialItemsFinalized.where(
       (model) => model.position == SpecialItemPosition.prepend,
     );
-    return index - prependItems.length;
+    return index - prependItems.length + 1;
   }
 
   @override


### PR DESCRIPTION
## What

`DefaultAssetPickerBuilderDelegate.assetGridItemSemanticIndex` currently returns:

```dart
return index - prependItems.length;
```

which produces a **0-based** index. As a result, screen readers (VoiceOver / TalkBack) announce assets as "Image 0, Image 1, ..." which is unintuitive and inconsistent with the **1-based** indices used by previous versions of this package (e.g. "Image 1, Image 2, ...").

This PR adds `+ 1` to restore the 1-based announced index.

## Why

The 1-based behavior was the long-standing convention in older versions of `wechat_assets_picker`, where the equivalent function returned `index + 1` (no prepend) or `index` (with prepend). Both branches yielded a 1-based announced index for the first asset.

When this method was refactored to support the new multi-prepend `specialItems` API, the `+ 1` offset was inadvertently dropped. The fix restores the original semantics in a single line, with no behavioral change to non-accessibility code paths.

## Behavior comparison

With one prepend item present:

| Grid index | Previous behavior | Current `main` | This PR |
|---|---|---|---|
| 0 (prepend tile) | n/a | n/a | n/a |
| 1 (1st asset) | 1 | **0** | **1** |
| 2 (2nd asset) | 2 | 1 | 2 |

Without prepend items:

| Grid index | Previous behavior | Current `main` | This PR |
|---|---|---|---|
| 0 (1st asset) | 1 | **0** | **1** |
| 1 (2nd asset) | 2 | 1 | 2 |

## Test plan

- Open a picker (with or without prepend special items).
- Enable VoiceOver (iOS) or TalkBack (Android).
- Swipe through the grid and confirm assets are announced as "Image 1, Image 2, ..." rather than "Image 0, Image 1, ...".

## Notes

- Single-line change in `lib/src/delegates/asset_picker_builder_delegate.dart`.
- CHANGELOG updated under the `Unreleased` section.